### PR TITLE
test: refactor to prefer nanoid over shortid

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@types/nanoid": "1.2.0",
     "@types/node": "10.12.0",
     "@types/query-string": "6.1.0",
-    "@types/shortid": "0.0.29",
     "coveralls": "3.0.2",
     "husky": "0.14.3",
     "jest": "23.6.0",
@@ -91,7 +90,6 @@
     "rollup-plugin-replace": "2.1.0",
     "rollup-plugin-terser": "3.0.0",
     "semantic-release": "15.9.17",
-    "shortid": "2.2.13",
     "ts-jest": "23.10.4",
     "tslint": "5.11.0",
     "typescript": "3.0.3"

--- a/src/rest/methods/agent.test.ts
+++ b/src/rest/methods/agent.test.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-expression-statement
-import { generate as generateId } from 'shortid'
+import generateId from 'nanoid'
 import restClient from '..'
 import { APP_ID, APP_PROPERTY_MANAGER_ID } from '../../../test/constants'
 import { EnumLocale, EnumTimezone } from '../types'

--- a/src/rest/methods/app.test.ts
+++ b/src/rest/methods/app.test.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-expression-statement
-import { generate as generateId } from 'shortid'
+import generateId from 'nanoid'
 import restClient from '..'
 import { USER_ID } from '../../../test/constants'
 

--- a/src/rest/methods/group.test.ts
+++ b/src/rest/methods/group.test.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-expression-statement
-import { generate as generateId } from 'shortid'
+import generateId from 'nanoid'
 import restClient from '..'
 import { APP_ID, APP_PROPERTY_MANAGER_ID } from '../../../test/constants'
 import { EnumCountryCode, EnumTimezone } from '../types'

--- a/src/rest/methods/property.test.ts
+++ b/src/rest/methods/property.test.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-expression-statement
-import { generate as generateId } from 'shortid'
+import generateId from 'nanoid'
 import restClient from '..'
 import { APP_ID } from '../../../test/constants'
 

--- a/src/rest/methods/registrationCode.test.ts
+++ b/src/rest/methods/registrationCode.test.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-expression-statement
-import { generate as generateId } from 'shortid'
+import generateId from 'nanoid'
 import restClient from '..'
 import { APP_PROPERTY_MANAGER_ID, USER_ID } from '../../../test/constants'
 import { EnumTimezone } from '../types'

--- a/src/rest/methods/unit.test.ts
+++ b/src/rest/methods/unit.test.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-expression-statement
-import { generate as generateId } from 'shortid'
+import generateId from 'nanoid'
 import restClient from '..'
 import { APP_ID, APP_PROPERTY_MANAGER_ID } from '../../../test/constants'
 import { EnumUnitType } from './unit'

--- a/src/rest/methods/user.test.ts
+++ b/src/rest/methods/user.test.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-expression-statement
-import { generate as generateId } from 'shortid'
+import generateId from 'nanoid'
 import restClient from '..'
 import { APP_ID, APP_PROPERTY_MANAGER_ID } from '../../../test/constants'
 import { times } from '../../utils/functional'

--- a/src/rest/methods/utilisationPeriod.test.ts
+++ b/src/rest/methods/utilisationPeriod.test.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-expression-statement
-import { generate as generateId } from 'shortid'
+import generateId from 'nanoid'
 import restClient from '..'
 import { APP_ID, APP_PROPERTY_MANAGER_ID } from '../../../test/constants'
 import { EnumLocale, EnumTimezone } from '../types'

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,11 +402,6 @@
   resolved "https://registry.yarnpkg.com/@types/query-string/-/query-string-6.1.0.tgz#5f721f9503bdf517d474c66cf4423da5dd2d5698"
   integrity sha512-6QxF7V3SkdyBRJ81GheWL9Nzr7uDrCZH0hkxdorNcXeBOeAPN5AUf1n9dpecaBOzxJAckWP4nIOeY1YxlhuMTQ==
 
-"@types/shortid@0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
-  integrity sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=
-
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.4.tgz#615bb2adb0cd34c8f4c447b5f6512fa1d8f16a2e"
@@ -4857,11 +4852,6 @@ nanoid@1.3.0:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-1.3.0.tgz#0b8d089c81d3b6cf61fcc16051432342b06f3ad9"
   integrity sha512-OP8SoC91Kyjl1sdSTEnM1xYh4gUEOSkUl6wRBUklWOPyfPRbeJbhvdhQYXEjVtZ1LI9amVMkIWQI2nO8O7DL9A==
 
-nanoid@^1.0.7:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-1.2.6.tgz#5b9427cabf41f5df1fc371b14c969ffcd3b095aa"
-  integrity sha512-um9vXiM407BaRbBNa0aKPzFBSD2fDbVmmA9TzCWWlxZvEBzTbixM7ss6GDS4G/cNMYeZSNFx5SzAgWoG1uHU9g==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -6648,13 +6638,6 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-
-shortid@2.2.13:
-  version "2.2.13"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.13.tgz#b2441e71c664ace458a341d343959f677910ef5b"
-  integrity sha512-dBuNnQGKrJNfjunmXI2X7bl1gnMO4PwbNxrTzO1JvilODmL7WyyCtA+DYxe9XunLXmxmgzFIvKPQ6XRAQrr46Q==
-  dependencies:
-    nanoid "^1.0.7"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
- nanoid is faster and cryptographically more secure.
- we already use nanoid in the library code