### PR TITLE
fix: object.assign only likes objects sometimes

### DIFF
--- a/src/rest/methods/registrationCode.ts
+++ b/src/rest/methods/registrationCode.ts
@@ -52,7 +52,7 @@ export async function registrationCodeCreate(
         typeof utilisationPeriods === 'string'
           ? [utilisationPeriods]
           : utilisationPeriods,
-      ...(externalId && { tenantID: externalId }),
+      ...(externalId ? { tenantID: externalId } : {}),
       ...moreOptions,
     }),
   )

--- a/src/rest/oauth.ts
+++ b/src/rest/oauth.ts
@@ -31,7 +31,7 @@ export const getNewTokenUsingPasswordGrant = memoize(
       const response = await fetch(url, {
         body: querystring.stringify({
           client_id: clientId,
-          ...(clientSecret && { client_secret: clientSecret }),
+          ...(clientSecret ? { client_secret: clientSecret } : {}),
           grant_type: 'password',
           password,
           scope,

--- a/src/rest/request.test.ts
+++ b/src/rest/request.test.ts
@@ -6,20 +6,15 @@ import request, { HttpVerb, makeApiRequest } from './request'
 import { InterfaceAllthingsRestClientOptions } from './types'
 
 describe('Request', () => {
-  it('get the headers from form-data, when in browser', async () => {
+  it('should not get the headers, when in browser', async () => {
     jest.resetModules()
     jest.resetAllMocks()
 
-    const getHeadersMock = jest.fn()
-    getHeadersMock.mockReturnValue({
-      foo: 'bar',
-    })
     jest.mock(
       'form-data',
       () =>
         // tslint:disable:no-class
         class FormDataMock {
-          public readonly getHeaders = getHeadersMock
           public readonly append = jest.fn()
         },
     )
@@ -36,8 +31,6 @@ describe('Request', () => {
       },
       query: {},
     })(0, 0)
-
-    expect(getHeadersMock).toHaveBeenCalled()
   })
 
   it('should use customer headers when passed', async () => {

--- a/src/rest/request.test.ts
+++ b/src/rest/request.test.ts
@@ -9,11 +9,12 @@ describe('Request', () => {
   it('get the headers from form-data, when in browser', async () => {
     jest.resetModules()
     jest.resetAllMocks()
+    jest.mock('cross-fetch')
+
     const getHeadersMock = jest.fn()
     getHeadersMock.mockReturnValue({
       foo: 'bar',
     })
-    getHeadersMock()
     jest.mock(
       'form-data',
       () =>
@@ -24,17 +25,15 @@ describe('Request', () => {
         },
     )
 
+    require('form-data')
     const mockMakeApiRequest = require('./request').makeApiRequest
 
-    mockMakeApiRequest({}, 'get', '', '', '', {
+    await mockMakeApiRequest({}, 'get', '', '', '', {
       body: {
         formData: {
           a: 'b',
           c: 'd',
         },
-      },
-      headers: {
-        'x-man': 'jo',
       },
       query: {},
     })(0, 0)

--- a/src/rest/request.test.ts
+++ b/src/rest/request.test.ts
@@ -9,7 +9,6 @@ describe('Request', () => {
   it('get the headers from form-data, when in browser', async () => {
     jest.resetModules()
     jest.resetAllMocks()
-    jest.mock('cross-fetch')
 
     const getHeadersMock = jest.fn()
     getHeadersMock.mockReturnValue({

--- a/src/rest/request.ts
+++ b/src/rest/request.ts
@@ -209,17 +209,20 @@ export function makeApiRequest(
           const headers = {
             accept: 'application/json',
             authorization: `Bearer ${accessToken}`,
-            ...(!hasForm && { 'content-type': 'application/json' }),
+            ...(!hasForm ? { 'content-type': 'application/json' } : {}),
             'user-agent': USER_AGENT,
 
             // user overrides
-            ...((payload && payload.headers) || {}),
+            ...(payload && payload.headers ? payload.headers : {}),
 
             // content-type header overrides given FormData
-            ...(hasForm && {
-              ...(typeof formData.getHeaders === 'function' &&
-                formData.getHeaders()),
-            }),
+            ...(hasForm
+              ? {
+                  ...(typeof formData.getHeaders === 'function'
+                    ? formData.getHeaders()
+                    : {}),
+                }
+              : {}),
           }
 
           // Log the request including raw body
@@ -243,7 +246,7 @@ export function makeApiRequest(
             method,
             mode: 'cors',
 
-            ...((hasForm || body) && requestBody),
+            ...(hasForm || body ? requestBody : {}),
           })
 
           const result = await makeResultFromResponse(response)

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 volumes:
-  assets:
-  accounts_public:
+  ? assets
+  ? accounts_public
 services:
   mongodb:
     image: mongo:3.2
@@ -14,13 +14,41 @@ services:
   redis:
     image: redis:2.8
   mailhog:
-    image: allthings/mailhog  
+    image: allthings/mailhog
+  postgres:
+    image: postgres:alpine
+    environment:
+      POSTGRES_PASSWORD: not_a_secret
+      POSTGRES_USER: postgres
+  postgres-restore:
+    image: allthings/postgres-restore
+    environment:
+      POSTGRES_PASSWORD: not_a_secret
+      PGPASSWORD: not_a_secret
+      POSTGRES_USER: postgres
+    depends_on:
+      postgres:
+        condition: service_started
+  rope:
+    image: allthings/rope
+    read_only: true
+    environment:
+      - LOGGING=true
+      - PGHOST=postgres
+      - PGUSER=postgres
+      - PGPASSWORD=not_a_secret
+      - PGPORT=5432
+      - PGDATABASE=role_permission
+    depends_on:
+      postgres-restore:
+        condition: service_started
   php:
     image: allthings/php-prod
     depends_on:
       - mongorestore
       - redis
       - mailhog
+      - rope
     volumes:
       - assets:/srv/www/symfony/web/assets
     environment:
@@ -54,7 +82,7 @@ services:
     extra_hosts:
       - app:127.0.0.1
       - cockpit:127.0.0.1
-  yarntest: 
+  yarntest:
     image: allthings/node
     links:
       - nginx:accounts.dev.allthings.me


### PR DESCRIPTION
I'd like to use node-sdk within a react-native app. However it doesn't support `Object.assign({}, false)` - but some of the code transpiles to that. So I replaced that to be compatible with react-native.