### PR TITLE
chore(deps): drop disused @types/got dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@commitlint/cli": "7.2.1",
     "@commitlint/config-conventional": "7.1.2",
     "@types/form-data": "2.2.1",
-    "@types/got": "8.3.4",
     "@types/jest": "23.3.7",
     "@types/mem": "1.1.2",
     "@types/nanoid": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -369,13 +369,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/got@8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/got/-/got-8.3.4.tgz#c6acca7252cdc9f7ae58070d13a45eb6ef9f88e7"
-  integrity sha512-0AbIQzpqQafYPFg26nwg5PfNgPLYwHeTP6z5F1u+5oypLIdpx34o5r8wYTTj3X3YYF2yPHtZPO/KYwlI8Nu/hQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/jest@23.3.7":
   version "23.3.7"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.7.tgz#77f9a4332ccf8db680a31818ade3ee454c831a79"


### PR DESCRIPTION
We no longer use `got`, so we don't need the typings.

Closes #97 
Closes #96 