### PR TITLE
fix: don't try to set properties removed in the rest api

### DIFF
--- a/src/rest/methods/app.ts
+++ b/src/rest/methods/app.ts
@@ -29,8 +29,6 @@ export async function appCreate(
 ): CreateAppResult {
   return client.post(`/v1/users/${userId}/apps`, {
     availableLocales: { '0': 'de_DE' },
-    contactEmail: 'no-reply@allthings.me',
-    fromEmailAddress: 'no-reply@alltings.me',
     ...data,
     siteUrl: data.siteUrl.replace('_', ''),
   })


### PR DESCRIPTION
This PR implements fixing a backwards incompatible change in the rest api. `contactEmail` and `fromEmailAddress` were removed from the app, breaking `appCreate` in the node-sdk. 