### PR TITLE
chore(test): drop async from describe blocks

### DIFF
--- a/src/rest/methods/registrationCode.test.ts
+++ b/src/rest/methods/registrationCode.test.ts
@@ -109,7 +109,7 @@ describe('registrationCodeCreate()', async () => {
   })
 })
 
-describe('registrationCodeUpdateById()', async () => {
+describe('registrationCodeUpdateById()', () => {
   it('should be able to update an existing registration code by id', async () => {
     const testExternalId = generateId()
 
@@ -138,7 +138,7 @@ describe('registrationCodeUpdateById()', async () => {
   })
 })
 
-describe('registrationCodeGetById()', async () => {
+describe('registrationCodeGetById()', () => {
   it('should be able to find a registration code by id', async () => {
     const testExternalId = generateId()
 
@@ -171,7 +171,7 @@ describe('registrationCodeGetById()', async () => {
   })
 })
 
-describe('registrationCodeDelete()', async () => {
+describe('registrationCodeDelete()', () => {
   it('should delete a registrationCode', async () => {
     const testExternalId = generateId()
 


### PR DESCRIPTION
To address jest warning:
> Returning a Promise from "describe" is not supported. Tests must be defined synchronously.
        Returning a value from "describe" will fail the test in a future version of Jest.
    
>          43 | })
>          44 | 
>        > 45 | describe('registrationCodeCreate()', async () => {
>             | ^
>          46 |   it('should be able to create a new registration code', async () => {
