### PR TITLE
 feat: appConfigGet()

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "roots": [
       "src/"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/test/setup.ts",
+    "setupFilesAfterEnv": ["<rootDir>/test/setup.ts"],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/src/rest/index.test.ts
+++ b/src/rest/index.test.ts
@@ -31,6 +31,19 @@ describe('Rest API Client', () => {
     expect(me).toHaveProperty('id')
   })
 
+  it('should respond with helpful error message when API responds with 401', async () => {
+    const anonRestClient = restClient({
+      clientId: undefined,
+      clientSecret: undefined,
+      password: undefined,
+      username: undefined,
+    })
+
+    const promise = anonRestClient.getCurrentUser()
+    await expect(promise).rejects.toThrow(Error)
+    await expect(promise).rejects.toThrow(/^API responded with 401/)
+  })
+
   it('should throw error when apiUrl parameter is not provided', async () => {
     expect(() => restClient({ apiUrl: undefined } as any)).toThrow()
   })

--- a/src/rest/index.test.ts
+++ b/src/rest/index.test.ts
@@ -39,10 +39,6 @@ describe('Rest API Client', () => {
     expect(() => restClient({ oauthUrl: undefined } as any)).toThrow()
   })
 
-  it('should throw error when clientId parameter is not provided', async () => {
-    expect(() => restClient({ clientId: undefined } as any)).toThrow()
-  })
-
   it('should use default options when none provided, and process.env variables unset', async () => {
     jest.resetModules()
 
@@ -71,19 +67,6 @@ describe('Rest API Client', () => {
     jest.resetModules()
     // restore process.env.ALLTHINGS_* test values
     require('../../test/setup')
-  })
-
-  it('should throw error when unable to get access token', async () => {
-    const client = restClient({
-      accessToken: undefined,
-      clientSecret: undefined,
-      password: undefined,
-      username: undefined,
-    })
-
-    await expect(
-      client.appCreate('foobar', { name: 'foobar', siteUrl: 'foobar.test' }),
-    ).rejects.toThrow('Unable to get OAuth2 access token')
   })
 
   describe('exposed OAuth', () => {

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -198,15 +198,6 @@ export default function restClient(
     throw new Error('OAuth2 URL is undefined.')
   }
 
-  // in browser access token can be obtained from URL during implicit flow
-  if (
-    !options.clientId &&
-    !options.accessToken &&
-    typeof window === 'undefined'
-  ) {
-    throw new Error('Missing required "clientId" or "accessToken" parameter .')
-  }
-
   const tokenRequester = makeFetchTokenRequester(
     `${options.oauthUrl}/oauth/token`,
   )

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -4,7 +4,7 @@ import { pseudoRandomString } from '../utils/random'
 import httpDelete from './delete'
 import httpGet from './get'
 import { agentCreate, agentCreatePermissions } from './methods/agent'
-import { appCreate } from './methods/app'
+import { appConfigGet, appCreate } from './methods/app'
 import {
   bucketAddFile,
   bucketCreate,
@@ -96,6 +96,7 @@ const API_METHODS: ReadonlyArray<any> = [
   agentCreatePermissions,
 
   // App
+  appConfigGet,
   appCreate,
 
   // Bucket

--- a/src/rest/methods/app.test.ts
+++ b/src/rest/methods/app.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable:no-expression-statement
 import generateId from 'nanoid'
 import restClient from '..'
-import { USER_ID } from '../../../test/constants'
+import { APP_ID, USER_ID } from '../../../test/constants'
 
 const client = restClient()
 
@@ -13,5 +13,23 @@ describe('appCreate()', () => {
     })
 
     expect(result).toBeTruthy()
+  })
+})
+
+describe('appConfigGet()', () => {
+  const anonRestClient = restClient({
+    clientId: undefined,
+    clientSecret: undefined,
+    password: undefined,
+    username: undefined,
+  })
+
+  it('should get configuration of an App by its id', async () => {
+    const result = await anonRestClient.appConfigGet(APP_ID)
+
+    expect(result).toMatchObject({
+      appId: APP_ID,
+      clientId: expect.any(String),
+    })
   })
 })

--- a/src/rest/methods/app.ts
+++ b/src/rest/methods/app.ts
@@ -1,4 +1,4 @@
-import { IAllthingsRestClient } from '../types'
+import { EnumCountryCode, EnumLocale, IAllthingsRestClient } from '../types'
 
 export interface IApp {
   readonly id: string
@@ -6,12 +6,23 @@ export interface IApp {
   readonly siteUrl: string
 }
 
+export interface IMicroApp {
+  readonly color: string
+  readonly label: { readonly [key in EnumLocale]: string }
+  readonly navigationHidden?: boolean
+  readonly order?: number
+  readonly url: string | null
+}
+
 export interface IAppConfig {
   readonly appId: string
   readonly appName: string
-  readonly appTitle: string
   readonly appSubTitle: string
+  readonly appTitle: string
+  readonly availableLocales: readonly EnumLocale[]
   readonly clientId: string
+  readonly country: EnumCountryCode
+  readonly microApps: readonly IMicroApp[]
 }
 
 export type PartialApp = Partial<IApp>

--- a/src/rest/methods/app.ts
+++ b/src/rest/methods/app.ts
@@ -6,6 +6,14 @@ export interface IApp {
   readonly siteUrl: string
 }
 
+export interface IAppConfig {
+  readonly appId: string
+  readonly appName: string
+  readonly appTitle: string
+  readonly appSubTitle: string
+  readonly clientId: string
+}
+
 export type PartialApp = Partial<IApp>
 
 export type CreateAppResult = Promise<IApp>
@@ -32,4 +40,23 @@ export async function appCreate(
     ...data,
     siteUrl: data.siteUrl.replace('_', ''),
   })
+}
+
+export type MethodAppConfigGet = (
+  appIdOrHostname: string,
+) => Promise<IAppConfig>
+
+export async function appConfigGet(
+  client: IAllthingsRestClient,
+  appIdOrHostname: string,
+): Promise<IAppConfig> {
+  const rawConfig = await client.get(
+    `/v1/apps/${appIdOrHostname}/configuration`,
+  )
+
+  return {
+    ...rawConfig,
+    appId: rawConfig.appID,
+    clientId: rawConfig.clientID,
+  }
 }

--- a/src/rest/methods/registrationCode.test.ts
+++ b/src/rest/methods/registrationCode.test.ts
@@ -42,7 +42,7 @@ beforeAll(async () => {
   ])).map(item => item.id)
 })
 
-describe('registrationCodeCreate()', async () => {
+describe('registrationCodeCreate()', () => {
   it('should be able to create a new registration code', async () => {
     const code = generateId()
     const testExternalId = generateId()

--- a/src/rest/request.ts
+++ b/src/rest/request.ts
@@ -196,10 +196,6 @@ export function makeApiRequest(
         TOKEN_REFRESH_STATUS_CODES.includes(previousResult.status),
     )
 
-    if (!oauthTokenStore.get('accessToken')) {
-      throw new Error('Unable to get OAuth2 access token.')
-    }
-
     try {
       return (
         refillReservoir() &&
@@ -223,9 +219,11 @@ export function makeApiRequest(
             new FormDataModule(),
           )
 
+          const accessToken = oauthTokenStore.get('accessToken')
+
           const headers = {
             accept: 'application/json',
-            authorization: `Bearer ${oauthTokenStore.get('accessToken')}`,
+            ...(accessToken ? { authorization: `Bearer ${accessToken}` } : {}),
             ...(!hasForm ? { 'content-type': 'application/json' } : {}),
             'user-agent': USER_AGENT,
 

--- a/src/rest/request.ts
+++ b/src/rest/request.ts
@@ -47,14 +47,7 @@ export type MethodHttpRequest = (
   payload?: IRequestOptions,
 ) => RequestResult
 
-const RETRYABLE_STATUS_CODES: ReadonlyArray<number> = [
-  401,
-  408,
-  429,
-  502,
-  503,
-  504,
-]
+const RETRYABLE_STATUS_CODES: ReadonlyArray<number> = [408, 429, 502, 503, 504]
 
 const TOKEN_REFRESH_STATUS_CODES: ReadonlyArray<number> = [401]
 
@@ -111,6 +104,13 @@ async function makeResultFromResponse(
   // E.g. retry 503s as it was likely a rate-limited request
   if (RETRYABLE_STATUS_CODES.includes(response.status)) {
     return response.clone()
+  }
+
+  if (response.status === 401) {
+    // provide a developer-friendly message in case credentials were not set by mistake
+    return new Error(
+      'API responded with 401 (Unauthorized). Make sure to provide credentials when creating restClient(). See https://github.com/allthings/node-sdk#installation--usage for details',
+    )
   }
 
   if (!response.ok) {

--- a/src/rest/types.ts
+++ b/src/rest/types.ts
@@ -5,7 +5,7 @@ import {
   MethodAgentCreate,
   MethodAgentCreatePermissions,
 } from './methods/agent'
-import { MethodAppCreate } from './methods/app'
+import { MethodAppConfigGet, MethodAppCreate } from './methods/app'
 import {
   MethodBucketAddFile,
   MethodBucketCreate,
@@ -181,6 +181,11 @@ export interface IAllthingsRestClient {
    * Create a new App.
    */
   readonly appCreate: MethodAppCreate
+
+  /**
+   * Gets config of an App by its id or hostname
+   */
+  readonly appConfigGet: MethodAppConfigGet
 
   // Bucket
 


### PR DESCRIPTION
Implements fetching App configuration by its id or hostname.

Since that is an endpoint that does not require authentication, allows to instantiate `restClient` without any oAuth-related parameters and gets rid of a constraint that requires `accessToken` to be in token store before sending a request.