### PR TITLE
fix: unset user-agent header in browser

### DIFF
--- a/src/rest/request.ts
+++ b/src/rest/request.ts
@@ -227,7 +227,9 @@ export function makeApiRequest(
             accept: 'application/json',
             authorization: `Bearer ${oauthTokenStore.get('accessToken')}`,
             ...(!hasForm ? { 'content-type': 'application/json' } : {}),
-            'user-agent': USER_AGENT,
+
+            // don't use unsafe header "user-agent" in browser
+            ...(typeof window === 'undefined' && { 'user-agent': USER_AGENT }),
 
             // user overrides
             ...(payload && payload.headers ? payload.headers : {}),


### PR DESCRIPTION
Each request throws an `Refused to set unsafe header "user-agent"` error in the browser console.
