### PR TITLE
fix: decrease request refill time

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,8 @@ const OAUTH_URL = 'https://accounts.allthings.me'
 export const QUEUE_CONCURRENCY = undefined
 export const QUEUE_DELAY = 0
 export const QUEUE_RESERVOIR = 30
-export const QUEUE_RESERVOIR_REFILL_INTERVAL = 50
+// Reflect nginx rate limit here (6 req/sec = ~166ms)
+export const QUEUE_RESERVOIR_REFILL_INTERVAL = 166
 
 // Request error handling options
 export const REQUEST_BACK_OFF_INTERVAL = 200

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ const OAUTH_URL = 'https://accounts.allthings.me'
 export const QUEUE_CONCURRENCY = undefined
 export const QUEUE_DELAY = 0
 export const QUEUE_RESERVOIR = 30
-export const QUEUE_RESERVOIR_REFILL_INTERVAL = 500
+export const QUEUE_RESERVOIR_REFILL_INTERVAL = 50
 
 // Request error handling options
 export const REQUEST_BACK_OFF_INTERVAL = 200


### PR DESCRIPTION
After increasing the rate limit on the nginx config the refill interval acts as the bottleneck for API requests. Decreasing the interval time accelerates the requests significantly.