### PR TITLE
feat: Add objectType and size to Unit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export {
   default as restClient,
   EnumCommunicationPreferenceChannel,
   EnumUserPermissionRole,
+  EnumUnitObjectType,
   EnumUnitType,
   EnumUserPermissionObjectType,
   EnumUserRelationType,

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -43,6 +43,7 @@ import {
   serviceProviderUpdateById,
 } from './methods/serviceProvider'
 import {
+  EnumUnitObjectType,
   EnumUnitType,
   getUnits,
   unitCreate,
@@ -181,6 +182,7 @@ const API_METHODS: ReadonlyArray<any> = [
 export {
   EnumCommunicationPreferenceChannel,
   EnumUserPermissionRole,
+  EnumUnitObjectType,
   EnumUnitType,
   EnumUserPermissionObjectType,
   EnumUserRelationType,

--- a/src/rest/methods/unit.test.ts
+++ b/src/rest/methods/unit.test.ts
@@ -2,7 +2,7 @@
 import generateId from 'nanoid'
 import restClient from '..'
 import { APP_ID, APP_PROPERTY_MANAGER_ID } from '../../../test/constants'
-import { EnumUnitType } from './unit'
+import { EnumUnitObjectType, EnumUnitType } from './unit'
 
 let sharedGroupId: string // tslint:disable-line no-let
 
@@ -10,6 +10,7 @@ const client = restClient()
 
 const testData = {
   name: 'Foobar Unit',
+  objectType: EnumUnitObjectType.flat,
   readOnly: true,
   type: EnumUnitType.rented,
 }

--- a/src/rest/methods/unit.test.ts
+++ b/src/rest/methods/unit.test.ts
@@ -10,9 +10,7 @@ const client = restClient()
 
 const testData = {
   name: 'Foobar Unit',
-  objectType: EnumUnitObjectType.flat,
   readOnly: true,
-  size: 20.0,
   type: EnumUnitType.rented,
 }
 
@@ -32,11 +30,18 @@ describe('unitCreate()', () => {
   })
 
   it('should be able to create a new unit', async () => {
-    const data = { ...testData, externalId: generateId() }
+    const data = {
+      ...testData,
+      externalId: generateId(),
+      objectType: EnumUnitObjectType.flat,
+      size: 20.0,
+    }
     const result = await client.unitCreate(sharedGroupId, data)
 
     expect(result.name).toEqual(data.name)
     expect(result.externalId).toEqual(data.externalId)
+    expect(result.objectType).toEqual(data.objectType)
+    expect(result.size).toEqual(data.size)
   })
 })
 
@@ -58,9 +63,13 @@ describe('unitUpdateById()', () => {
 
     expect(unit.name).toEqual(initialData.name)
     expect(unit.externalId).toEqual(initialData.externalId)
+    expect(unit.objectType).toBe(null)
+    expect(unit.size).toBe(null)
 
     const updateData = {
       externalId: generateId(),
+      objectType: EnumUnitObjectType.garage,
+      size: 32.5,
       type: EnumUnitType.owned,
     }
 
@@ -68,6 +77,8 @@ describe('unitUpdateById()', () => {
 
     expect(result.type).toEqual(updateData.type)
     expect(result.externalId).toEqual(updateData.externalId)
+    expect(result.objectType).toEqual(updateData.objectType)
+    expect(result.size).toEqual(updateData.size)
   })
 })
 

--- a/src/rest/methods/unit.test.ts
+++ b/src/rest/methods/unit.test.ts
@@ -12,6 +12,7 @@ const testData = {
   name: 'Foobar Unit',
   objectType: EnumUnitObjectType.flat,
   readOnly: true,
+  size: 20.0,
   type: EnumUnitType.rented,
 }
 

--- a/src/rest/methods/unit.ts
+++ b/src/rest/methods/unit.ts
@@ -79,15 +79,15 @@ export enum EnumUnitType {
 }
 
 export interface IUnit {
-  readonly externalId: string | null
+  readonly externalId?: string
   readonly id: string
   readonly name: string
-  readonly objectType: EnumUnitObjectType
-  readonly readOnly: boolean
-  readonly size: number | null
-  readonly stats: {
-    readonly tenantCount: number | null
-    readonly invitationCount: number | null
+  readonly objectType?: EnumUnitObjectType
+  readonly readOnly?: boolean
+  readonly size?: number
+  readonly stats?: {
+    readonly invitationCount?: number
+    readonly tenantCount?: number
   }
   readonly type: EnumUnitType
 }

--- a/src/rest/methods/unit.ts
+++ b/src/rest/methods/unit.ts
@@ -83,11 +83,12 @@ export interface IUnit {
   readonly id: string
   readonly name: string
   readonly objectType: EnumUnitObjectType
+  readonly readOnly: boolean
+  readonly size: number | null
   readonly stats: {
     readonly tenantCount: number | null
     readonly invitationCount: number | null
   }
-  readonly readOnly: boolean
   readonly type: EnumUnitType
 }
 

--- a/src/rest/methods/unit.ts
+++ b/src/rest/methods/unit.ts
@@ -1,5 +1,78 @@
 import { EntityResultList, IAllthingsRestClient } from '../types'
 
+export enum EnumUnitObjectType {
+  adjoiningRoom = 'adjoining-room',
+  advertisingSpace = 'advertising-space',
+  aerial = 'aerial',
+  apartmentBuilding = 'apartment-building',
+  atm = 'atm',
+  atmRoom = 'atm-room',
+  attic = 'attic',
+  atticFlat = 'attic-flat',
+  bank = 'bank',
+  basment = 'basment',
+  bikeShed = 'bike-shed',
+  buildingLaw = 'building-law',
+  cafeteria = 'cafeteria',
+  caretakerRoom = 'caretaker-room',
+  carport = 'carport',
+  cellar = 'cellar',
+  commercialProperty = 'commercial-property',
+  commonRoom = 'common-room',
+  deliveryZone = 'delivery-zone',
+  diverse = 'diverse',
+  doubleParkingSpace = 'double-parking-space',
+  engineeringRoom = 'engineering-room',
+  entertainment = 'entertainment',
+  environment = 'environment',
+  estate = 'estate',
+  fillingStation = 'filling-station',
+  fitnessCenter = 'fitness-center',
+  flat = 'flat',
+  freeZone = 'free-zone',
+  garage = 'garage',
+  garden = 'garden',
+  gardenFlat = 'garden-flat',
+  heatingFacilities = 'heating-facilities',
+  hotel = 'hotel',
+  incidentalRentalExpenses = 'incidental-rental-expenses',
+  industry = 'industry',
+  kiosk = 'kiosk',
+  kitchen = 'kitchen',
+  loft = 'loft',
+  machine = 'machine',
+  maisonette = 'maisonette',
+  medicalPractice = 'medical-practice',
+  mopedShed = 'moped-shed',
+  motorcycleParkingSpace = 'motorcycle-parking-space',
+  office = 'office',
+  oneFamilyHouse = 'one-family-house',
+  parkingBox = 'parking-box',
+  parkingGarage = 'parking-garage',
+  parkingSpace = 'parking-space',
+  parkingSpaces = 'parking-spaces',
+  penthouse = 'penthouse',
+  productionPlant = 'production-plant',
+  pub = 'pub',
+  publicArea = 'public-area',
+  restaurant = 'restaurant',
+  retirementHome = 'retirement-home',
+  salesFloor = 'sales-floor',
+  school = 'school',
+  shelter = 'shelter',
+  storage = 'storage',
+  store = 'store',
+  storeroom = 'storeroom',
+  studio = 'studio',
+  terrace = 'terrace',
+  toilets = 'toilets',
+  utilityRoom = 'utility-room',
+  variableParkingSpace = 'variable-parking-space',
+  variableRoom = 'variable-room',
+  visitorParkingSpace = 'visitor-parking-space',
+  workshop = 'workshop',
+}
+
 export enum EnumUnitType {
   rented = 'rented',
   owned = 'owned',
@@ -9,12 +82,13 @@ export interface IUnit {
   readonly externalId: string | null
   readonly id: string
   readonly name: string
+  readonly objectType: EnumUnitObjectType
   readonly stats: {
     readonly tenantCount: number | null
     readonly invitationCount: number | null
   }
-  readonly type: EnumUnitType
   readonly readOnly: boolean
+  readonly type: EnumUnitType
 }
 
 export type PartialUnit = Partial<IUnit>


### PR DESCRIPTION
This PR adds:
- `EnumUnitObjectType` enum
- `objectType` field to Unit
- `size` field to Unit
