### PR TITLE
fix: enum naming and export to index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
   EnumUnitType,
   EnumUserPermissionObjectType,
   EnumUserRelationType,
+  EnumUtilisationPeriodType,
 } from './rest'
 export {
   EnumCountryCode,

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -72,6 +72,7 @@ import {
   userRelationDelete,
 } from './methods/userRelation'
 import {
+  EnumUtilisationPeriodType,
   utilisationPeriodAddRegistrationCode,
   utilisationPeriodCheckInUser,
   utilisationPeriodCheckOutUser,
@@ -186,6 +187,7 @@ export {
   EnumUnitType,
   EnumUserPermissionObjectType,
   EnumUserRelationType,
+  EnumUtilisationPeriodType,
 }
 
 /*

--- a/src/rest/methods/utilisationPeriod.test.ts
+++ b/src/rest/methods/utilisationPeriod.test.ts
@@ -5,7 +5,7 @@ import { APP_ID, APP_PROPERTY_MANAGER_ID } from '../../../test/constants'
 import { EnumLocale, EnumTimezone } from '../types'
 import { EnumUnitType } from './unit'
 import { remapEmbeddedUser } from './user'
-import { EUtilisationPeriodType } from './utilisationPeriod'
+import { EnumUtilisationPeriodType } from './utilisationPeriod'
 
 let sharedUnitId: string // tslint:disable-line no-let
 let sharedUtilisationPeriodId: string // tslint:disable-line no-let
@@ -38,7 +38,7 @@ describe('utilisationPeriodCreate()', () => {
       externalId: generateId(),
       readOnly: true,
       startDate: '2050-01-01',
-      type: EUtilisationPeriodType.tenant,
+      type: EnumUtilisationPeriodType.tenant,
     }
     const result = await client.utilisationPeriodCreate(sharedUnitId, data)
 

--- a/src/rest/methods/utilisationPeriod.ts
+++ b/src/rest/methods/utilisationPeriod.ts
@@ -5,7 +5,7 @@ import {
 } from './registrationCode'
 import { IUser, remapEmbeddedUser } from './user'
 
-export enum EUtilisationPeriodType {
+export enum EnumUtilisationPeriodType {
   tenant = 'tenant',
   ownership = 'ownership',
   vacant = 'vacant',
@@ -27,7 +27,7 @@ export interface IUtilisationPeriod {
     readonly invitationCount: number | null
   }
   readonly tenantIds: ReadonlyArray<string>
-  readonly type: EUtilisationPeriodType
+  readonly type: EnumUtilisationPeriodType
   readonly userCount: number | null
   readonly users: ReadonlyArray<IUser>
   readonly readOnly: boolean
@@ -66,7 +66,7 @@ export type MethodUtilisationPeriodCreate = (
   data: PartialUtilisationPeriod & {
     readonly startDate: string
     readonly endDate?: string
-    readonly type?: EUtilisationPeriodType
+    readonly type?: EnumUtilisationPeriodType
   },
 ) => UtilisationPeriodResult
 
@@ -76,7 +76,7 @@ export async function utilisationPeriodCreate(
   data: PartialUtilisationPeriod & {
     readonly startDate: string
     readonly endDate?: string
-    readonly type?: EUtilisationPeriodType
+    readonly type?: EnumUtilisationPeriodType
   },
 ): UtilisationPeriodResult {
   const { tenantIDs: tenantIds, _embedded, ...result } = await client.post(


### PR DESCRIPTION
This fix changes the name of the enum to `EnumUtilisationPeriodType` reflecting the naming conventions in node-sdk. It also exports this enum from index.ts  