### PR TITLE
fix: mutilated query data

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,8 @@
     "repositoryUrl": "https://github.com/allthings/node-sdk.git"
   },
   "resolutions": {
-    "handlebars": ">=4.5.2",
+    "handlebars": ">=4.5.3",
+    "mem": ">=4.0.0",
     "jest/**/braces": ">=2.3.1",
     "js-yaml": ">=3.13.1",
     "tar": ">=4.4.2",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,7 +1,3 @@
-interface IDictionary<T = any> {
-  readonly [key: string]: T
-}
-
 type List<T> = ReadonlyArray<T>
 
 declare namespace NodeJS {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,12 +1,12 @@
-interface IndexSignature {
-  readonly [key: string]: any
+interface IDictionary<T = any> {
+  readonly [key: string]: T
 }
 
 type List<T> = ReadonlyArray<T>
 
 declare namespace NodeJS {
   interface Global {
-    window: any
+    readonly window: any
   }
 }
 

--- a/src/oauth/authorizationCodeGrant.ts
+++ b/src/oauth/authorizationCodeGrant.ts
@@ -5,7 +5,7 @@ import { TokenRequester } from './types'
 export const RESPONSE_TYPE = 'code'
 export const GRANT_TYPE = 'authorization_code'
 
-const castToAuthorizationRequestParams = (params: IDictionary) => {
+const castToAuthorizationRequestParams = (params: Record<string, any>) => {
   const { redirectUri, clientId, scope, state } = params
 
   if (!clientId) {
@@ -29,7 +29,9 @@ const castToAuthorizationRequestParams = (params: IDictionary) => {
   }
 }
 
-export const isEligibleForClientRedirect = (params: IDictionary): boolean => {
+export const isEligibleForClientRedirect = (
+  params: Record<string, any>,
+): boolean => {
   try {
     return !!castToAuthorizationRequestParams(params)
   } catch {
@@ -37,12 +39,12 @@ export const isEligibleForClientRedirect = (params: IDictionary): boolean => {
   }
 }
 
-export const getRedirectUrl = (params: IDictionary) =>
+export const getRedirectUrl = (params: Record<string, any>) =>
   `${params.oauthUrl}/oauth/authorize?${querystring.stringify(
     castToAuthorizationRequestParams(params),
   )}`
 
-const castToTokenRequestParams = (params: IDictionary) => {
+const castToTokenRequestParams = (params: Record<string, any>) => {
   const { authorizationCode, redirectUri, clientId, clientSecret } = params
 
   if (!clientId) {
@@ -72,7 +74,7 @@ const castToTokenRequestParams = (params: IDictionary) => {
   }
 }
 
-export const isEligible = (params: IDictionary): boolean => {
+export const isEligible = (params: Record<string, any>): boolean => {
   try {
     return !!castToTokenRequestParams(params)
   } catch {
@@ -82,5 +84,5 @@ export const isEligible = (params: IDictionary): boolean => {
 
 export const requestToken = (
   tokenRequester: TokenRequester,
-  params: IDictionary,
+  params: Record<string, any>,
 ) => tokenRequester(castToTokenRequestParams(params))

--- a/src/oauth/authorizationCodeGrant.ts
+++ b/src/oauth/authorizationCodeGrant.ts
@@ -5,7 +5,7 @@ import { TokenRequester } from './types'
 export const RESPONSE_TYPE = 'code'
 export const GRANT_TYPE = 'authorization_code'
 
-const castToAuthorizationRequestParams = (params: IndexSignature) => {
+const castToAuthorizationRequestParams = (params: IDictionary) => {
   const { redirectUri, clientId, scope, state } = params
 
   if (!clientId) {
@@ -29,9 +29,7 @@ const castToAuthorizationRequestParams = (params: IndexSignature) => {
   }
 }
 
-export const isEligibleForClientRedirect = (
-  params: IndexSignature,
-): boolean => {
+export const isEligibleForClientRedirect = (params: IDictionary): boolean => {
   try {
     return !!castToAuthorizationRequestParams(params)
   } catch {
@@ -39,12 +37,12 @@ export const isEligibleForClientRedirect = (
   }
 }
 
-export const getRedirectUrl = (params: IndexSignature) =>
+export const getRedirectUrl = (params: IDictionary) =>
   `${params.oauthUrl}/oauth/authorize?${querystring.stringify(
     castToAuthorizationRequestParams(params),
   )}`
 
-const castToTokenRequestParams = (params: IndexSignature) => {
+const castToTokenRequestParams = (params: IDictionary) => {
   const { authorizationCode, redirectUri, clientId, clientSecret } = params
 
   if (!clientId) {
@@ -74,7 +72,7 @@ const castToTokenRequestParams = (params: IndexSignature) => {
   }
 }
 
-export const isEligible = (params: IndexSignature): boolean => {
+export const isEligible = (params: IDictionary): boolean => {
   try {
     return !!castToTokenRequestParams(params)
   } catch {
@@ -84,5 +82,5 @@ export const isEligible = (params: IndexSignature): boolean => {
 
 export const requestToken = (
   tokenRequester: TokenRequester,
-  params: IndexSignature,
+  params: IDictionary,
 ) => tokenRequester(castToTokenRequestParams(params))

--- a/src/oauth/clientCredentialsGrant.ts
+++ b/src/oauth/clientCredentialsGrant.ts
@@ -2,7 +2,7 @@ import { TokenRequester } from './types'
 
 export const GRANT_TYPE = 'client_credentials'
 
-const castClientOptionsToRequestParams = (clientOptions: IndexSignature) => {
+const castClientOptionsToRequestParams = (clientOptions: IDictionary) => {
   const { scope, clientId, clientSecret } = clientOptions
 
   if (!clientId) {
@@ -25,7 +25,7 @@ const castClientOptionsToRequestParams = (clientOptions: IndexSignature) => {
   }
 }
 
-export const isEligible = (clientOptions: IndexSignature): boolean => {
+export const isEligible = (clientOptions: IDictionary): boolean => {
   try {
     return !!castClientOptionsToRequestParams(clientOptions)
   } catch {
@@ -35,5 +35,5 @@ export const isEligible = (clientOptions: IndexSignature): boolean => {
 
 export const requestToken = (
   oauthTokenRequest: TokenRequester,
-  clientOptions: IndexSignature,
+  clientOptions: IDictionary,
 ) => oauthTokenRequest(castClientOptionsToRequestParams(clientOptions))

--- a/src/oauth/clientCredentialsGrant.ts
+++ b/src/oauth/clientCredentialsGrant.ts
@@ -2,7 +2,9 @@ import { TokenRequester } from './types'
 
 export const GRANT_TYPE = 'client_credentials'
 
-const castClientOptionsToRequestParams = (clientOptions: IDictionary) => {
+const castClientOptionsToRequestParams = (
+  clientOptions: Record<string, any>,
+) => {
   const { scope, clientId, clientSecret } = clientOptions
 
   if (!clientId) {
@@ -25,7 +27,7 @@ const castClientOptionsToRequestParams = (clientOptions: IDictionary) => {
   }
 }
 
-export const isEligible = (clientOptions: IDictionary): boolean => {
+export const isEligible = (clientOptions: Record<string, any>): boolean => {
   try {
     return !!castClientOptionsToRequestParams(clientOptions)
   } catch {
@@ -35,5 +37,5 @@ export const isEligible = (clientOptions: IDictionary): boolean => {
 
 export const requestToken = (
   oauthTokenRequest: TokenRequester,
-  clientOptions: IDictionary,
+  clientOptions: Record<string, any>,
 ) => oauthTokenRequest(castClientOptionsToRequestParams(clientOptions))

--- a/src/oauth/createTokenStore.ts
+++ b/src/oauth/createTokenStore.ts
@@ -1,7 +1,7 @@
 import { ITokenStore } from './types'
 
 export default function createTokenStore(
-  initialToken?: IndexSignature,
+  initialToken?: IDictionary,
 ): ITokenStore {
   const token = new Map<string, string>(Object.entries(initialToken || {}))
 

--- a/src/oauth/createTokenStore.ts
+++ b/src/oauth/createTokenStore.ts
@@ -1,7 +1,7 @@
 import { ITokenStore } from './types'
 
 export default function createTokenStore(
-  initialToken?: IDictionary,
+  initialToken?: Record<string, any>,
 ): ITokenStore {
   const token = new Map<string, string>(Object.entries(initialToken || {}))
 

--- a/src/oauth/implicitGrant.ts
+++ b/src/oauth/implicitGrant.ts
@@ -2,7 +2,7 @@ import querystring from 'query-string'
 
 export const RESPONSE_TYPE = 'token'
 
-const castToAuthorizationRequestParams = (params: IDictionary) => {
+const castToAuthorizationRequestParams = (params: Record<string, any>) => {
   const { clientId, scope, state, redirectUri } = params
 
   if (!clientId) {
@@ -20,7 +20,9 @@ const castToAuthorizationRequestParams = (params: IDictionary) => {
   }
 }
 
-export const isEligibleForClientRedirect = (params: IDictionary): boolean => {
+export const isEligibleForClientRedirect = (
+  params: Record<string, any>,
+): boolean => {
   try {
     return !!castToAuthorizationRequestParams(params)
   } catch {
@@ -28,7 +30,7 @@ export const isEligibleForClientRedirect = (params: IDictionary): boolean => {
   }
 }
 
-export const getRedirectUrl = (params: IDictionary) =>
+export const getRedirectUrl = (params: Record<string, any>) =>
   `${params.oauthUrl}/oauth/authorize?${querystring.stringify(
     castToAuthorizationRequestParams(params),
   )}`

--- a/src/oauth/implicitGrant.ts
+++ b/src/oauth/implicitGrant.ts
@@ -2,7 +2,7 @@ import querystring from 'query-string'
 
 export const RESPONSE_TYPE = 'token'
 
-const castToAuthorizationRequestParams = (params: IndexSignature) => {
+const castToAuthorizationRequestParams = (params: IDictionary) => {
   const { clientId, scope, state, redirectUri } = params
 
   if (!clientId) {
@@ -20,9 +20,7 @@ const castToAuthorizationRequestParams = (params: IndexSignature) => {
   }
 }
 
-export const isEligibleForClientRedirect = (
-  params: IndexSignature,
-): boolean => {
+export const isEligibleForClientRedirect = (params: IDictionary): boolean => {
   try {
     return !!castToAuthorizationRequestParams(params)
   } catch {
@@ -30,7 +28,7 @@ export const isEligibleForClientRedirect = (
   }
 }
 
-export const getRedirectUrl = (params: IndexSignature) =>
+export const getRedirectUrl = (params: IDictionary) =>
   `${params.oauthUrl}/oauth/authorize?${querystring.stringify(
     castToAuthorizationRequestParams(params),
   )}`

--- a/src/oauth/makeFetchTokenRequester.ts
+++ b/src/oauth/makeFetchTokenRequester.ts
@@ -7,7 +7,7 @@ import { IOAuthToken } from './types'
 const logger = makeLogger('OAuth Token Request')
 
 const makeFetchTokenRequester = (url: string) => async (
-  params: IDictionary,
+  params: Record<string, any>,
 ): Promise<IOAuthToken> => {
   try {
     const response = await fetch(url, {

--- a/src/oauth/makeFetchTokenRequester.ts
+++ b/src/oauth/makeFetchTokenRequester.ts
@@ -7,7 +7,7 @@ import { IOAuthToken } from './types'
 const logger = makeLogger('OAuth Token Request')
 
 const makeFetchTokenRequester = (url: string) => async (
-  params: IndexSignature,
+  params: IDictionary,
 ): Promise<IOAuthToken> => {
   try {
     const response = await fetch(url, {

--- a/src/oauth/maybeUpdateToken.ts
+++ b/src/oauth/maybeUpdateToken.ts
@@ -10,7 +10,7 @@ import { ITokenStore, TokenRequester } from './types'
 export default async function maybeUpdateToken(
   oauthTokenStore: ITokenStore,
   tokenFetcher: TokenRequester,
-  options: IDictionary,
+  options: Record<string, any>,
   mustRefresh = false,
 ): Promise<void> {
   if (!mustRefresh && oauthTokenStore.get('accessToken')) {

--- a/src/oauth/maybeUpdateToken.ts
+++ b/src/oauth/maybeUpdateToken.ts
@@ -10,7 +10,7 @@ import { ITokenStore, TokenRequester } from './types'
 export default async function maybeUpdateToken(
   oauthTokenStore: ITokenStore,
   tokenFetcher: TokenRequester,
-  options: IndexSignature,
+  options: IDictionary,
   mustRefresh = false,
 ): Promise<void> {
   if (!mustRefresh && oauthTokenStore.get('accessToken')) {

--- a/src/oauth/passwordGrant.ts
+++ b/src/oauth/passwordGrant.ts
@@ -2,7 +2,7 @@ import { TokenRequester } from './types'
 
 export const GRANT_TYPE = 'password'
 
-const castToTokenRequestParams = (params: IndexSignature) => {
+const castToTokenRequestParams = (params: IDictionary) => {
   const { username, password, scope, clientId, clientSecret } = params
 
   if (!clientId) {
@@ -33,7 +33,7 @@ const castToTokenRequestParams = (params: IndexSignature) => {
   }
 }
 
-export const isEligible = (params: IndexSignature): boolean => {
+export const isEligible = (params: IDictionary): boolean => {
   try {
     return !!castToTokenRequestParams(params)
   } catch {
@@ -43,5 +43,5 @@ export const isEligible = (params: IndexSignature): boolean => {
 
 export const requestToken = (
   tokenRequester: TokenRequester,
-  params: IndexSignature,
+  params: IDictionary,
 ) => tokenRequester(castToTokenRequestParams(params))

--- a/src/oauth/passwordGrant.ts
+++ b/src/oauth/passwordGrant.ts
@@ -2,7 +2,7 @@ import { TokenRequester } from './types'
 
 export const GRANT_TYPE = 'password'
 
-const castToTokenRequestParams = (params: IDictionary) => {
+const castToTokenRequestParams = (params: Record<string, any>) => {
   const { username, password, scope, clientId, clientSecret } = params
 
   if (!clientId) {
@@ -33,7 +33,7 @@ const castToTokenRequestParams = (params: IDictionary) => {
   }
 }
 
-export const isEligible = (params: IDictionary): boolean => {
+export const isEligible = (params: Record<string, any>): boolean => {
   try {
     return !!castToTokenRequestParams(params)
   } catch {
@@ -43,5 +43,5 @@ export const isEligible = (params: IDictionary): boolean => {
 
 export const requestToken = (
   tokenRequester: TokenRequester,
-  params: IDictionary,
+  params: Record<string, any>,
 ) => tokenRequester(castToTokenRequestParams(params))

--- a/src/oauth/refreshTokenGrant.ts
+++ b/src/oauth/refreshTokenGrant.ts
@@ -2,7 +2,7 @@ import { TokenRequester } from './types'
 
 export const GRANT_TYPE = 'refresh_token'
 
-const castToTokenRequestParams = (params: IndexSignature) => {
+const castToTokenRequestParams = (params: IDictionary) => {
   const { clientId, clientSecret, refreshToken, scope } = params
 
   if (!clientId) {
@@ -26,7 +26,7 @@ const castToTokenRequestParams = (params: IndexSignature) => {
   }
 }
 
-export const isEligible = (params: IndexSignature): boolean => {
+export const isEligible = (params: IDictionary): boolean => {
   try {
     return !!castToTokenRequestParams(params)
   } catch {
@@ -36,5 +36,5 @@ export const isEligible = (params: IndexSignature): boolean => {
 
 export const requestToken = (
   tokenRequester: TokenRequester,
-  params: IndexSignature,
+  params: IDictionary,
 ) => tokenRequester(castToTokenRequestParams(params))

--- a/src/oauth/refreshTokenGrant.ts
+++ b/src/oauth/refreshTokenGrant.ts
@@ -2,7 +2,7 @@ import { TokenRequester } from './types'
 
 export const GRANT_TYPE = 'refresh_token'
 
-const castToTokenRequestParams = (params: IDictionary) => {
+const castToTokenRequestParams = (params: Record<string, any>) => {
   const { clientId, clientSecret, refreshToken, scope } = params
 
   if (!clientId) {
@@ -26,7 +26,7 @@ const castToTokenRequestParams = (params: IDictionary) => {
   }
 }
 
-export const isEligible = (params: IDictionary): boolean => {
+export const isEligible = (params: Record<string, any>): boolean => {
   try {
     return !!castToTokenRequestParams(params)
   } catch {
@@ -36,5 +36,5 @@ export const isEligible = (params: IDictionary): boolean => {
 
 export const requestToken = (
   tokenRequester: TokenRequester,
-  params: IDictionary,
+  params: Record<string, any>,
 ) => tokenRequester(castToTokenRequestParams(params))

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -10,4 +10,6 @@ export interface ITokenStore {
   readonly reset: () => void
 }
 
-export type TokenRequester = (params: IDictionary) => Promise<IOAuthToken>
+export type TokenRequester = (
+  params: Record<string, any>,
+) => Promise<IOAuthToken>

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -10,4 +10,4 @@ export interface ITokenStore {
   readonly reset: () => void
 }
 
-export type TokenRequester = (params: IndexSignature) => Promise<IOAuthToken>
+export type TokenRequester = (params: IDictionary) => Promise<IOAuthToken>

--- a/src/rest/delete.ts
+++ b/src/rest/delete.ts
@@ -4,13 +4,13 @@ export type DeleteResult = Promise<any>
 
 export type MethodHttpDelete = (
   method: string,
-  body?: IDictionary,
+  body?: Record<string, any>,
 ) => DeleteResult
 
 export default async function del(
   request: MethodHttpRequest,
   method: string,
-  body: IDictionary,
+  body: Record<string, any>,
 ): DeleteResult {
   return request('delete', method, { body })
 }

--- a/src/rest/delete.ts
+++ b/src/rest/delete.ts
@@ -4,13 +4,13 @@ export type DeleteResult = Promise<any>
 
 export type MethodHttpDelete = (
   method: string,
-  body?: { readonly [key: string]: any },
+  body?: IDictionary,
 ) => DeleteResult
 
 export default async function del(
   request: MethodHttpRequest,
   method: string,
-  body: { readonly [key: string]: any },
+  body: IDictionary,
 ): DeleteResult {
   return request('delete', method, { body })
 }

--- a/src/rest/get.ts
+++ b/src/rest/get.ts
@@ -2,15 +2,12 @@ import { MethodHttpRequest } from './request'
 
 export type GetResult = Promise<any>
 
-export type MethodHttpGet = (
-  method: string,
-  query?: { readonly [parameter: string]: string },
-) => GetResult
+export type MethodHttpGet = (method: string, query?: IDictionary) => GetResult
 
 export default async function get(
   request: MethodHttpRequest,
   method: string,
-  query: { readonly [parameter: string]: string },
+  query: IDictionary,
 ): GetResult {
   return request('get', method, { query })
 }

--- a/src/rest/get.ts
+++ b/src/rest/get.ts
@@ -2,12 +2,15 @@ import { MethodHttpRequest } from './request'
 
 export type GetResult = Promise<any>
 
-export type MethodHttpGet = (method: string, query?: IDictionary) => GetResult
+export type MethodHttpGet = (
+  method: string,
+  query?: Record<string, any>,
+) => GetResult
 
 export default async function get(
   request: MethodHttpRequest,
   method: string,
-  query: IDictionary,
+  query: Record<string, any>,
 ): GetResult {
   return request('get', method, { query })
 }

--- a/src/rest/methods/group.ts
+++ b/src/rest/methods/group.ts
@@ -107,7 +107,7 @@ export async function groupUpdateById(
 export type MethodGetGroups = (
   page?: number,
   limit?: number,
-  filter?: IndexSignature,
+  filter?: IDictionary,
 ) => GroupResultList
 
 export async function getGroups(
@@ -119,9 +119,11 @@ export async function getGroups(
   const {
     _embedded: { items: groups },
     total,
-  } = await client.get(
-    `/v1/groups?page=${page}&limit=${limit}&filter=${JSON.stringify(filter)}`,
-  )
+  } = await client.get('/v1/groups', {
+    filter: JSON.stringify(filter),
+    limit,
+    page,
+  })
 
   return { _embedded: { items: groups }, total }
 }

--- a/src/rest/methods/group.ts
+++ b/src/rest/methods/group.ts
@@ -107,7 +107,7 @@ export async function groupUpdateById(
 export type MethodGetGroups = (
   page?: number,
   limit?: number,
-  filter?: IDictionary,
+  filter?: Record<string, any>,
 ) => GroupResultList
 
 export async function getGroups(

--- a/src/rest/methods/property.test.ts
+++ b/src/rest/methods/property.test.ts
@@ -11,6 +11,12 @@ const testData = {
   timezone: 'Europe/Berlin',
 }
 
+const testDataUmlauts = {
+  name: 'Pröpärty',
+  readOnly: true,
+  timezone: 'Europe/Berlin',
+}
+
 describe('propertyCreate()', () => {
   it('should be able to create a new property', async () => {
     const data = { ...testData, externalId: generateId() }
@@ -60,5 +66,17 @@ describe('getProperties()', () => {
 
     const result2 = await client.getProperties(1, limit)
     expect(result2._embedded.items).toHaveLength(limit)
+  })
+
+  it('should be able to get a property with umlauts', async () => {
+    await client.propertyCreate(APP_ID, {
+      ...testDataUmlauts,
+      externalId: generateId(),
+    })
+
+    const result = await client.getProperties(undefined, undefined, {
+      name: testDataUmlauts.name,
+    })
+    expect(result._embedded.items[0].name).toEqual(testDataUmlauts.name)
   })
 })

--- a/src/rest/methods/property.ts
+++ b/src/rest/methods/property.ts
@@ -72,7 +72,7 @@ export async function propertyUpdateById(
 export type MethodGetProperties = (
   page?: number,
   limit?: number,
-  filter?: IndexSignature,
+  filter?: IDictionary,
 ) => PropertyResultList
 
 export async function getProperties(
@@ -84,11 +84,11 @@ export async function getProperties(
   const {
     _embedded: { items: properties },
     total,
-  } = await client.get(
-    `/v1/properties?page=${page}&limit=${limit}&filter=${JSON.stringify(
-      filter,
-    )}`,
-  )
+  } = await client.get('/v1/properties', {
+    filter: JSON.stringify(filter),
+    limit,
+    page,
+  })
 
   return { _embedded: { items: properties }, total }
 }

--- a/src/rest/methods/property.ts
+++ b/src/rest/methods/property.ts
@@ -72,7 +72,7 @@ export async function propertyUpdateById(
 export type MethodGetProperties = (
   page?: number,
   limit?: number,
-  filter?: IDictionary,
+  filter?: Record<string, any>,
 ) => PropertyResultList
 
 export async function getProperties(

--- a/src/rest/methods/unit.ts
+++ b/src/rest/methods/unit.ts
@@ -157,7 +157,7 @@ export async function unitUpdateById(
 export type MethodGetUnits = (
   page?: number,
   limit?: number,
-  filter?: IDictionary,
+  filter?: Record<string, any>,
 ) => UnitResultList
 
 export async function getUnits(

--- a/src/rest/methods/unit.ts
+++ b/src/rest/methods/unit.ts
@@ -157,7 +157,7 @@ export async function unitUpdateById(
 export type MethodGetUnits = (
   page?: number,
   limit?: number,
-  filter?: IndexSignature,
+  filter?: IDictionary,
 ) => UnitResultList
 
 export async function getUnits(
@@ -169,9 +169,11 @@ export async function getUnits(
   const {
     _embedded: { items: units },
     total,
-  } = await client.get(
-    `/v1/units?page=${page}&limit=${limit}&filter=${JSON.stringify(filter)}`,
-  )
+  } = await client.get('/v1/units', {
+    filter: JSON.stringify(filter),
+    limit,
+    page,
+  })
 
   return { _embedded: { items: units }, total }
 }

--- a/src/rest/methods/user.ts
+++ b/src/rest/methods/user.ts
@@ -152,7 +152,7 @@ export async function userCreate(
 export type MethodGetUsers = (
   page?: number,
   limit?: number,
-  filter?: IDictionary,
+  filter?: Record<string, any>,
 ) => UserResultList
 
 export async function getUsers(
@@ -246,13 +246,13 @@ export async function userCreatePermission(
   },
 ): UserPermissionResult {
   const { objectId: objectID, ...rest } = data
-  const {
-    objectID: resultObjectId,
-    ...result
-  } = await client.post(`/v1/users/${userId}/permissions`, {
-    ...rest,
-    objectID,
-  })
+  const { objectID: resultObjectId, ...result } = await client.post(
+    `/v1/users/${userId}/permissions`,
+    {
+      ...rest,
+      objectID,
+    },
+  )
 
   return {
     ...result,

--- a/src/rest/methods/user.ts
+++ b/src/rest/methods/user.ts
@@ -152,7 +152,7 @@ export async function userCreate(
 export type MethodGetUsers = (
   page?: number,
   limit?: number,
-  filter?: IndexSignature,
+  filter?: IDictionary,
 ) => UserResultList
 
 export async function getUsers(
@@ -164,9 +164,11 @@ export async function getUsers(
   const {
     _embedded: { items: users },
     total,
-  } = await client.get(
-    `/v1/users?page=${page}&limit=${limit}&filter=${JSON.stringify(filter)}`,
-  )
+  } = await client.get('/v1/users', {
+    filter: JSON.stringify(filter),
+    limit,
+    page,
+  })
 
   return { _embedded: { items: users.map(remapUserResult) }, total }
 }
@@ -244,10 +246,13 @@ export async function userCreatePermission(
   },
 ): UserPermissionResult {
   const { objectId: objectID, ...rest } = data
-  const { objectID: resultObjectId, ...result } = await client.post(
-    `/v1/users/${userId}/permissions`,
-    { ...rest, objectID },
-  )
+  const {
+    objectID: resultObjectId,
+    ...result
+  } = await client.post(`/v1/users/${userId}/permissions`, {
+    ...rest,
+    objectID,
+  })
 
   return {
     ...result,

--- a/src/rest/patch.ts
+++ b/src/rest/patch.ts
@@ -4,13 +4,13 @@ export type PatchResult = Promise<any>
 
 export type MethodHttpPatch = (
   method: string,
-  body?: IDictionary,
+  body?: Record<string, any>,
 ) => PatchResult
 
 export default async function patch(
   request: MethodHttpRequest,
   method: string,
-  body: IDictionary,
+  body: Record<string, any>,
 ): PatchResult {
   return request('patch', method, { body })
 }

--- a/src/rest/patch.ts
+++ b/src/rest/patch.ts
@@ -4,13 +4,13 @@ export type PatchResult = Promise<any>
 
 export type MethodHttpPatch = (
   method: string,
-  body?: { readonly [key: string]: any },
+  body?: IDictionary,
 ) => PatchResult
 
 export default async function patch(
   request: MethodHttpRequest,
   method: string,
-  body: { readonly [key: string]: any },
+  body: IDictionary,
 ): PatchResult {
   return request('patch', method, { body })
 }

--- a/src/rest/post.ts
+++ b/src/rest/post.ts
@@ -2,21 +2,15 @@ import { MethodHttpRequest } from './request'
 
 export type PostResult = Promise<any>
 
-interface IFromDataType {
-  readonly [key: string]: any
-}
-
 export type MethodHttpPost = (
   method: string,
-  body?:
-    | { readonly [key: string]: any }
-    | { readonly ['formData']: IFromDataType },
+  body?: IDictionary | { readonly ['formData']: IDictionary },
 ) => PostResult
 
 export default async function post(
   request: MethodHttpRequest,
   method: string,
-  body: { readonly [key: string]: any },
+  body: IDictionary,
 ): PostResult {
   return request('post', method, { body })
 }

--- a/src/rest/post.ts
+++ b/src/rest/post.ts
@@ -2,10 +2,7 @@ import { MethodHttpRequest } from './request'
 
 export type PostResult = Promise<any>
 
-export type MethodHttpPost = (
-  method: string,
-  body?: IDictionary | { readonly ['formData']: IDictionary },
-) => PostResult
+export type MethodHttpPost = (method: string, body?: IDictionary) => PostResult
 
 export default async function post(
   request: MethodHttpRequest,

--- a/src/rest/post.ts
+++ b/src/rest/post.ts
@@ -2,12 +2,15 @@ import { MethodHttpRequest } from './request'
 
 export type PostResult = Promise<any>
 
-export type MethodHttpPost = (method: string, body?: IDictionary) => PostResult
+export type MethodHttpPost = (
+  method: string,
+  body?: Record<string, any>,
+) => PostResult
 
 export default async function post(
   request: MethodHttpRequest,
   method: string,
-  body: IDictionary,
+  body: Record<string, any>,
 ): PostResult {
   return request('post', method, { body })
 }

--- a/src/rest/request.test.ts
+++ b/src/rest/request.test.ts
@@ -153,4 +153,40 @@ describe('Request', () => {
       true,
     )
   })
+
+  it('should respect existing ? in url', async () => {
+    mockFetch.mockResolvedValueOnce({
+      clone: () => ({ text: () => '' }),
+      headers: new Map([['content-type', 'text/json']]),
+      ok: true,
+      status: 200,
+    })
+
+    await makeApiRequest(
+      mockTokenStore,
+      fakeOauthTokenFetcher,
+      DEFAULT_API_WRAPPER_OPTIONS,
+      'get',
+      '/foo?bar=1',
+      {
+        query: { limit: '1' },
+      },
+    )({}, 0)
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      'https://api.dev.allthings.me/api/foo?bar=1&limit=1',
+      {
+        cache: 'no-cache',
+        credentials: 'omit',
+        headers: {
+          accept: 'application/json',
+          authorization: `Bearer ${mockTokenResult.accessToken}`,
+          'content-type': 'application/json',
+          'user-agent': 'Allthings Node SDK REST Client/0.0.0-development',
+        },
+        method: 'GET',
+        mode: 'cors',
+      },
+    )
+  })
 })

--- a/src/rest/request.ts
+++ b/src/rest/request.ts
@@ -205,11 +205,12 @@ export function makeApiRequest(
         refillReservoir() &&
         (await queue.schedule(async () => {
           const method = httpMethod.toUpperCase()
-          const url = `${options.apiUrl}/api${apiMethod}${
+          const payloadQuery =
             payload && payload.query
-              ? '?' + querystring.stringify(payload.query)
+              ? (apiMethod.includes('?') ? '&' : '?') +
+                querystring.stringify(payload.query)
               : ''
-          }`
+          const url = `${options.apiUrl}/api${apiMethod}${payloadQuery}`
           const body = payload && payload.body
           const hasForm = isFormData(body)
           const form = isFormData(body) ? body.formData : {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3090,10 +3090,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@>=4.5.2, handlebars@^4.0.2, handlebars@^4.1.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.2.tgz#5a4eb92ab5962ca3415ac188c86dc7f784f76a0f"
-  integrity sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==
+handlebars@>=4.5.3, handlebars@^4.0.2, handlebars@^4.1.2:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -4794,10 +4794,10 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-map-age-cleaner@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz#098fb15538fd3dbe461f12745b0ca8568d4e3f74"
-  integrity sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==
+map-age-cleaner@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
   dependencies:
     p-defer "^1.0.0"
 
@@ -4845,21 +4845,13 @@ meant@~1.0.1:
   resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.1.tgz#66044fea2f23230ec806fb515efea29c44d2115d"
   integrity sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==
 
-mem@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
-  integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
+mem@>=4.0.0, mem@^1.1.0, mem@^4.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-6.0.0.tgz#f79bb110b90b688a2d1468566e66a911794abee5"
+  integrity sha512-1zHBKMg0Xd4yw3EQju6cjJiNtPomak7aNkuJx19QihMco09icTTsLZtVvxfxBxQH/NNvjtA1skR9lDlvkdW46g==
   dependencies:
-    mimic-fn "^1.0.0"
-
-mem@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-4.0.0.tgz#6437690d9471678f6cc83659c00cbafcd6b0cdaf"
-  integrity sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==
-  dependencies:
-    map-age-cleaner "^0.1.1"
-    mimic-fn "^1.0.0"
-    p-is-promise "^1.1.0"
+    map-age-cleaner "^0.1.3"
+    mimic-fn "^3.0.0"
 
 meow@5.0.0:
   version "5.0.0"
@@ -4966,6 +4958,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-fn@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.0.0.tgz#76044cfa8818bbf6999c5c9acadf2d3649b14b4b"
+  integrity sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ==
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -5772,11 +5769,6 @@ p-finally@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
   integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
-
-p-is-promise@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
-  integrity sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
 
 p-is-promise@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- This fixes the bug that queries sent to the API were falsy encoded
- It also cleans up the typings for `IDictionary` aka `IndexSignature` types