### PR TITLE
feat: make it able to not invite agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,9 @@
     "roots": [
       "src/"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/test/setup.ts",
+    "setupFilesAfterEnv": [
+      "<rootDir>/test/setup.ts"
+    ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/src/rest/methods/agent.test.ts
+++ b/src/rest/methods/agent.test.ts
@@ -35,10 +35,12 @@ describe('agentCreate()', () => {
       APP_PROPERTY_MANAGER_ID,
       generateId(),
       data,
+      true,
     )
 
     const result = await client.userGetById(agent.id)
 
+    expect(result.inviteEmailSent).toBeTruthy()
     expect(result.email).toEqual(data.email)
     expect(result.externalId).toEqual(data.externalId)
     expect(result.roles).toEqual([])
@@ -59,6 +61,24 @@ describe('agentCreate()', () => {
     expect(ourManagerAgent.externalId).toEqual(agent.externalId)
     expect(ourManagerAgent.roles).toEqual(agent.roles)
     expect(ourManagerAgent.type).toEqual(agent.type)
+  })
+
+  it('should be able to suppress sending an invitation on a new agent', async () => {
+    const data = {
+      ...testData,
+      email: generateId() + '@foobar.test',
+      externalId: generateId(),
+    }
+
+    const agent = await client.agentCreate(
+      APP_ID,
+      APP_PROPERTY_MANAGER_ID,
+      generateId(),
+      data,
+      false,
+    )
+    const result = await client.userGetById(agent.id)
+    expect(result.inviteEmailSent).toBeFalsy()
   })
 
   it('should be able to create a new agent with a externalAgentCompany associated', async () => {
@@ -91,6 +111,7 @@ describe('agentCreate()', () => {
       APP_PROPERTY_MANAGER_ID,
       generateId(),
       data,
+      true,
       externalAgentCompany.id,
     )
 
@@ -132,6 +153,7 @@ describe('agentCreatePermissions()', () => {
       APP_PROPERTY_MANAGER_ID,
       generateId(),
       data,
+      false,
     )
 
     const agentAppPermissionResult = await client.agentCreatePermissions(

--- a/src/rest/methods/agent.test.ts
+++ b/src/rest/methods/agent.test.ts
@@ -23,7 +23,7 @@ const testData = {
 }
 
 describe('agentCreate()', () => {
-  it('should be able to create a new agent', async () => {
+  it('should be able to create a new agent and send an invitation per default', async () => {
     const data = {
       ...testData,
       email: generateId() + '@foobar.test',
@@ -35,7 +35,6 @@ describe('agentCreate()', () => {
       APP_PROPERTY_MANAGER_ID,
       generateId(),
       data,
-      true,
     )
 
     const result = await client.userGetById(agent.id)

--- a/src/rest/methods/agent.ts
+++ b/src/rest/methods/agent.ts
@@ -53,7 +53,7 @@ export async function agentCreate(
   // trigger sending of invitation emails to agents, then return data
   return (
     !(
-      (sendInvitation !== undefined ? sendInvitation : true) &&
+      (typeof sendInvitation !== 'undefined' ? sendInvitation : true) &&
       (await client.post(`/v1/users/${user.id}/invitations`))
     ) && {
       ...user,

--- a/src/rest/methods/agent.ts
+++ b/src/rest/methods/agent.ts
@@ -22,7 +22,7 @@ export type MethodAgentCreate = (
     readonly email: string
     readonly locale: EnumLocale
   },
-  sendInvitation: boolean,
+  sendInvitation?: boolean,
   externalAgentCompany?: string,
 ) => UserResult
 
@@ -35,7 +35,7 @@ export async function agentCreate(
     readonly email: string
     readonly locale: EnumLocale
   },
-  sendInvitation: boolean,
+  sendInvitation?: boolean,
   externalAgentCompany?: string,
 ): UserResult {
   const user = await client.userCreate(appId, username, {
@@ -53,7 +53,8 @@ export async function agentCreate(
   // trigger sending of invitation emails to agents, then return data
   return (
     !(
-      sendInvitation && (await client.post(`/v1/users/${user.id}/invitations`))
+      (sendInvitation !== undefined ? sendInvitation : true) &&
+      (await client.post(`/v1/users/${user.id}/invitations`))
     ) && {
       ...user,
       ...manager,

--- a/src/rest/methods/agent.ts
+++ b/src/rest/methods/agent.ts
@@ -22,6 +22,7 @@ export type MethodAgentCreate = (
     readonly email: string
     readonly locale: EnumLocale
   },
+  sendInvitation: boolean,
   externalAgentCompany?: string,
 ) => UserResult
 
@@ -34,6 +35,7 @@ export async function agentCreate(
     readonly email: string
     readonly locale: EnumLocale
   },
+  sendInvitation: boolean,
   externalAgentCompany?: string,
 ): UserResult {
   const user = await client.userCreate(appId, username, {
@@ -50,7 +52,9 @@ export async function agentCreate(
 
   // trigger sending of invitation emails to agents, then return data
   return (
-    !(await client.post(`/v1/users/${user.id}/invitations`)) && {
+    !(
+      sendInvitation && (await client.post(`/v1/users/${user.id}/invitations`))
+    ) && {
       ...user,
       ...manager,
     }

--- a/src/rest/methods/user.ts
+++ b/src/rest/methods/user.ts
@@ -36,6 +36,7 @@ export interface IUser {
   readonly externalId: string | null
   readonly gender: EnumGender
   readonly id: string
+  readonly inviteEmailSent: boolean
   readonly lastLogin: string | null
   readonly locale: EnumLocale
   readonly nativeAppInstallIds: ReadonlyArray<string> | null
@@ -244,10 +245,13 @@ export async function userCreatePermission(
   },
 ): UserPermissionResult {
   const { objectId: objectID, ...rest } = data
-  const { objectID: resultObjectId, ...result } = await client.post(
-    `/v1/users/${userId}/permissions`,
-    { ...rest, objectID },
-  )
+  const {
+    objectID: resultObjectId,
+    ...result
+  } = await client.post(`/v1/users/${userId}/permissions`, {
+    ...rest,
+    objectID,
+  })
 
   return {
     ...result,


### PR DESCRIPTION
This PR implements the possibility to not send an invitation when an agent is created (e.g. for externalAgents)