### PR TITLE
feat: ticket creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
   EnumResource,
   EnumServiceProviderType,
   EnumTimezone,
+  EnumCommunicationMethodType,
   IAllthingsRestClient,
   IAllthingsRestClientOptions,
 } from './rest/types'

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -58,7 +58,11 @@ import {
   serviceProviderGetById,
   serviceProviderUpdateById,
 } from './methods/serviceProvider'
-import { ticketCreate, ticketGetById } from './methods/ticket'
+import {
+  ticketCreateOnServiceProvider,
+  ticketCreateOnUser,
+  ticketGetById,
+} from './methods/ticket'
 import {
   EnumUnitObjectType,
   EnumUnitType,
@@ -167,7 +171,8 @@ const API_METHODS: ReadonlyArray<any> = [
   registrationCodeGetById,
 
   // Ticket
-  ticketCreate,
+  ticketCreateOnUser,
+  ticketCreateOnServiceProvider,
   ticketGetById,
 
   // Unit

--- a/src/rest/methods/conversation.test.ts
+++ b/src/rest/methods/conversation.test.ts
@@ -6,7 +6,10 @@ import restClient from '..'
 const client = restClient()
 
 const CONVERSATION_ID = '5aa7cd7bd4959e004112e136'
-const USER_ID = '5a9d5ce40ecb3300413971a7'
+const CREATED_BY = {
+  type: 'email',
+  value: 'pr-coreyplatt@allthings.me',
+}
 
 describe('conversationGetById()', () => {
   it('should be able to get a conversation by ID', async () => {
@@ -21,11 +24,16 @@ describe('conversationCreateMessage()', () => {
     const content = 'some message'
     const result = await client.conversationCreateMessage(CONVERSATION_ID, {
       body: content,
-      userId: USER_ID,
+      createdBy: CREATED_BY,
     })
 
     expect(result.content.content).toEqual(content)
-    expect(result._embedded.createdBy.id).toEqual(USER_ID)
+    expect(result._embedded.createdByCommunicationMethod.value).toEqual(
+      CREATED_BY.value,
+    )
+    expect(result._embedded.createdByCommunicationMethod.type).toEqual(
+      CREATED_BY.type,
+    )
   })
 
   it('should be able to add a message to a conversation with attachments', async () => {
@@ -38,11 +46,11 @@ describe('conversationCreateMessage()', () => {
         },
       ],
       body: content,
-      userId: USER_ID,
+      createdBy: CREATED_BY,
     })
 
     expect(result.content.description).toEqual(content)
-    expect(result._embedded.createdBy.id).toEqual(USER_ID)
+    // expect(result._embedded.createdBy.id).toEqual(USER_ID)
 
     if (result.content.files) {
       expect(result.content.files.length).toEqual(1)

--- a/src/rest/methods/conversation.test.ts
+++ b/src/rest/methods/conversation.test.ts
@@ -2,14 +2,9 @@
 
 import { readFileSync } from 'fs'
 import restClient from '..'
+import { COMMUNICATION_METHOD, CONVERSATION_ID } from '../../../test/constants'
 
 const client = restClient()
-
-const CONVERSATION_ID = '5aa7cd7bd4959e004112e136'
-const CREATED_BY = {
-  type: 'email',
-  value: 'pr-coreyplatt@allthings.me',
-}
 
 describe('conversationGetById()', () => {
   it('should be able to get a conversation by ID', async () => {
@@ -24,15 +19,15 @@ describe('conversationCreateMessage()', () => {
     const content = 'some message'
     const result = await client.conversationCreateMessage(CONVERSATION_ID, {
       body: content,
-      createdBy: CREATED_BY,
+      createdBy: {
+        type: COMMUNICATION_METHOD.type,
+        value: COMMUNICATION_METHOD.value,
+      },
     })
 
     expect(result.content.content).toEqual(content)
-    expect(result._embedded.createdByCommunicationMethod.value).toEqual(
-      CREATED_BY.value,
-    )
-    expect(result._embedded.createdByCommunicationMethod.type).toEqual(
-      CREATED_BY.type,
+    expect(result._embedded.createdByCommunicationMethod).toMatchObject(
+      COMMUNICATION_METHOD,
     )
   })
 
@@ -46,11 +41,16 @@ describe('conversationCreateMessage()', () => {
         },
       ],
       body: content,
-      createdBy: CREATED_BY,
+      createdBy: {
+        type: COMMUNICATION_METHOD.type,
+        value: COMMUNICATION_METHOD.value,
+      },
     })
 
     expect(result.content.description).toEqual(content)
-    // expect(result._embedded.createdBy.id).toEqual(USER_ID)
+    expect(result._embedded.createdByCommunicationMethod).toMatchObject(
+      COMMUNICATION_METHOD,
+    )
 
     if (result.content.files) {
       expect(result.content.files.length).toEqual(1)

--- a/src/rest/methods/conversation.ts
+++ b/src/rest/methods/conversation.ts
@@ -1,5 +1,5 @@
 import { createManyFilesSorted } from '../../utils/upload'
-import { IAllthingsRestClient } from '../types'
+import { EnumCommunicationMethodType, IAllthingsRestClient } from '../types'
 
 export interface IConversation {
   readonly id: string
@@ -27,7 +27,10 @@ export interface IMessagePayload {
     readonly filename: string
   }>
   readonly body: string
-  readonly createdBy: { readonly type: string; readonly value: string }
+  readonly createdBy: {
+    readonly type: EnumCommunicationMethodType
+    readonly value: string
+  }
 }
 
 export type ConversationResult = Promise<IConversation>

--- a/src/rest/methods/conversation.ts
+++ b/src/rest/methods/conversation.ts
@@ -27,7 +27,7 @@ export interface IMessagePayload {
     readonly filename: string
   }>
   readonly body: string
-  readonly userId: string
+  readonly createdBy: { readonly type: string; readonly value: string }
 }
 
 export type ConversationResult = Promise<IConversation>
@@ -63,7 +63,7 @@ export async function conversationCreateMessage(
   conversationId: string,
   messageData: IMessagePayload,
 ): ConversationCreateMessageResult {
-  const url = `/v1/conversations/${conversationId}/messages?forUser=${messageData.userId}`
+  const url = `/v1/conversations/${conversationId}/messages`
 
   const payload =
     messageData.attachments && messageData.attachments.length
@@ -74,6 +74,7 @@ export async function conversationCreateMessage(
               await createManyFilesSorted(messageData.attachments, client)
             ).success,
           },
+          createdBy: messageData.createdBy,
           internal: false,
           type: 'file',
         }
@@ -81,6 +82,7 @@ export async function conversationCreateMessage(
           content: {
             content: messageData.body,
           },
+          createdBy: messageData.createdBy,
           type: 'text',
         }
 

--- a/src/rest/methods/ticket.test.ts
+++ b/src/rest/methods/ticket.test.ts
@@ -85,7 +85,7 @@ describe('ticketCreateOnServiceProvider()', () => {
       SERVICE_PROVIDER_ID,
       {
         category: CATEGORY_ID,
-        channel: 'app',
+        channel: 'App-575027e58178f56a008b4568',
         createdByCommunicationMethod: {
           type: 'email',
           value: 'pr-coreyplatt@allthings.me',

--- a/src/rest/methods/ticket.test.ts
+++ b/src/rest/methods/ticket.test.ts
@@ -4,20 +4,25 @@ import restClient from '../index'
 
 const client = restClient()
 
-const userId = '5a9d5ce40ecb3300492bf186'
-const utilisationPeriodId = '5a9d65cd0ecb330045742be3'
-const categoryId = '5728504906128762098b456e'
+const USER_ID = '5a9d5ce40ecb3300492bf186'
+const UTILISATION_PERIOD_ID = '5a9d65cd0ecb330045742be3'
+const CATEGORY_ID = '5728504906128762098b456e'
+const SERVICE_PROVIDER_ID = '5a818c07ef5f2f00441146a2'
 
 afterEach(jest.clearAllMocks)
 
 describe('ticketGetById()', () => {
   it('should be able to get a ticket by ID', async () => {
-    const { id } = await client.ticketCreate(userId, utilisationPeriodId, {
-      category: categoryId,
-      description: 'description',
-      inputChannel: 'test',
-      title: 'title',
-    })
+    const { id } = await client.ticketCreateOnUser(
+      USER_ID,
+      UTILISATION_PERIOD_ID,
+      {
+        category: CATEGORY_ID,
+        description: 'description',
+        inputChannel: 'test',
+        title: 'title',
+      },
+    )
     const result = await client.ticketGetById(id)
 
     expect(result.id).toEqual(id)
@@ -26,20 +31,78 @@ describe('ticketGetById()', () => {
   })
 })
 
-describe('ticketCreate()', () => {
+describe('ticketCreateOnUser()', () => {
   it('should be able to create a ticket', async () => {
-    const result = await client.ticketCreate(userId, utilisationPeriodId, {
-      category: categoryId,
-      description: 'description',
-      files: [
-        {
-          content: readFileSync(__dirname + '/../../../test/fixtures/1x1.png'),
-          filename: '2x2.png',
+    const result = await client.ticketCreateOnUser(
+      USER_ID,
+      UTILISATION_PERIOD_ID,
+      {
+        category: CATEGORY_ID,
+        description: 'description',
+        files: [
+          {
+            content: readFileSync(
+              __dirname + '/../../../test/fixtures/1x1.png',
+            ),
+            filename: '2x2.png',
+          },
+        ],
+        inputChannel: 'test',
+        title: 'title',
+      },
+    )
+
+    expect(result.description).toEqual('description')
+    expect(result.title).toEqual('title')
+    expect(result.files.length).toEqual(1)
+  })
+})
+
+describe('ticketCreateOnServiceProvider()', () => {
+  it('should be able to create a ticket on a service provider', async () => {
+    const result = await client.ticketCreateOnServiceProvider(
+      SERVICE_PROVIDER_ID,
+      {
+        category: CATEGORY_ID,
+        channel: 'app',
+        createdByCommunicationMethod: {
+          type: 'email',
+          value: 'pr-coreyplatt@allthings.me',
         },
-      ],
-      inputChannel: 'test',
-      title: 'title',
-    })
+        description: 'description',
+        inputChannel: 'test',
+        title: 'title',
+      },
+    )
+
+    expect(result.description).toEqual('description')
+    expect(result.title).toEqual('title')
+    expect(result.files.length).toEqual(0)
+  })
+
+  it('should be able to create a ticket on a service provider with files', async () => {
+    const result = await client.ticketCreateOnServiceProvider(
+      SERVICE_PROVIDER_ID,
+      {
+        category: CATEGORY_ID,
+        channel: 'app',
+        createdByCommunicationMethod: {
+          type: 'email',
+          value: 'pr-coreyplatt@allthings.me',
+        },
+        description: 'description',
+        files: [
+          {
+            content: readFileSync(
+              __dirname + '/../../../test/fixtures/1x1.png',
+            ),
+            filename: '2x2.png',
+          },
+        ],
+        inputChannel: 'test',
+        title: 'title',
+      },
+    )
 
     expect(result.description).toEqual('description')
     expect(result.title).toEqual('title')

--- a/src/rest/methods/ticket.test.ts
+++ b/src/rest/methods/ticket.test.ts
@@ -1,13 +1,16 @@
 // tslint:disable:no-expression-statement
 import { readFileSync } from 'fs'
+import {
+  APP_CHANNEL,
+  CATEGORY_ID,
+  COMMUNICATION_METHOD,
+  SERVICE_PROVIDER_ID,
+  USER_ID,
+  UTILISATION_PERIOD_ID,
+} from '../../../test/constants'
 import restClient from '../index'
 
 const client = restClient()
-
-const USER_ID = '5a9d5ce40ecb3300492bf186'
-const UTILISATION_PERIOD_ID = '5a9d65cd0ecb330045742be3'
-const CATEGORY_ID = '5728504906128762098b456e'
-const SERVICE_PROVIDER_ID = '5a818c07ef5f2f00441146a2'
 
 afterEach(jest.clearAllMocks)
 
@@ -32,7 +35,7 @@ describe('ticketGetById()', () => {
 })
 
 describe('ticketCreateOnUser()', () => {
-  it('should be able to create a ticket', async () => {
+  it('should be able to create a ticket on a user', async () => {
     const result = await client.ticketCreateOnUser(
       USER_ID,
       UTILISATION_PERIOD_ID,
@@ -66,8 +69,8 @@ describe('ticketCreateOnServiceProvider()', () => {
         category: CATEGORY_ID,
         channel: 'app',
         createdByCommunicationMethod: {
-          type: 'email',
-          value: 'pr-coreyplatt@allthings.me',
+          type: COMMUNICATION_METHOD.type,
+          value: COMMUNICATION_METHOD.value,
         },
         description: 'description',
         inputChannel: 'test',
@@ -85,10 +88,10 @@ describe('ticketCreateOnServiceProvider()', () => {
       SERVICE_PROVIDER_ID,
       {
         category: CATEGORY_ID,
-        channel: 'App-575027e58178f56a008b4568',
+        channel: APP_CHANNEL,
         createdByCommunicationMethod: {
-          type: 'email',
-          value: 'pr-coreyplatt@allthings.me',
+          type: COMMUNICATION_METHOD.type,
+          value: COMMUNICATION_METHOD.value,
         },
         description: 'description',
         files: [

--- a/src/rest/methods/ticket.ts
+++ b/src/rest/methods/ticket.ts
@@ -29,6 +29,11 @@ export interface ITicketCreatePayload {
     readonly filename: string
   }>
   readonly category: string
+  readonly channel?: string
+  readonly createdByCommunicationMethod?: {
+    readonly type: string
+    readonly value: string
+  }
   readonly description: string
   readonly inputChannel: string
   readonly title: string
@@ -96,16 +101,16 @@ export async function ticketGetById(
 }
 
 /*
-  Create a ticket
+  Create a ticket on a user
  */
 
-export type MethodTicketCreate = (
+export type MethodTicketCreateOnUser = (
   userId: string,
   utilisationPeriodId: string,
   payload: ITicketCreatePayload,
 ) => TicketResult
 
-export async function ticketCreate(
+export async function ticketCreateOnUser(
   client: IAllthingsRestClient,
   userId: string,
   utilisationPeriodId: string,
@@ -117,5 +122,30 @@ export async function ticketCreate(
       ? (await createManyFilesSorted(payload.files, client)).success
       : [],
     utilisationPeriod: utilisationPeriodId,
+  })
+}
+
+/*
+  Create a ticket on a service provider
+
+  Allows for a ticket to be created on a service provider where a user might not
+  exist (Anonymous tickets)
+ */
+
+export type MethodTicketCreateOnServiceProvider = (
+  serviceProviderId: string,
+  payload: ITicketCreatePayload,
+) => TicketResult
+
+export async function ticketCreateOnServiceProvider(
+  client: IAllthingsRestClient,
+  serviceProviderId: string,
+  payload: ITicketCreatePayload,
+): TicketResult {
+  return client.post(`/v1/property-managers/${serviceProviderId}/tickets`, {
+    ...payload,
+    files: payload.files
+      ? (await createManyFilesSorted(payload.files, client)).success
+      : [],
   })
 }

--- a/src/rest/types.ts
+++ b/src/rest/types.ts
@@ -51,7 +51,11 @@ import {
   MethodServiceProviderGetById,
   MethodServiceProviderUpdateById,
 } from './methods/serviceProvider'
-import { MethodTicketCreate, MethodTicketGetById } from './methods/ticket'
+import {
+  MethodTicketCreateOnServiceProvider,
+  MethodTicketCreateOnUser,
+  MethodTicketGetById,
+} from './methods/ticket'
 import {
   MethodGetUnits,
   MethodUnitCreate,
@@ -381,7 +385,12 @@ export interface IAllthingsRestClient {
   /**
    * Create a ticket
    */
-  readonly ticketCreate: MethodTicketCreate
+  readonly ticketCreateOnUser: MethodTicketCreateOnUser
+
+  /**
+   * Create an anonymous ticket
+   */
+  readonly ticketCreateOnServiceProvider: MethodTicketCreateOnServiceProvider
 
   /**
    * Get a ticket by its ID

--- a/src/rest/types.ts
+++ b/src/rest/types.ts
@@ -136,6 +136,10 @@ export enum EnumServiceProviderType {
   craftspeople = 'craftspeople',
 }
 
+export enum EnumCommunicationMethodType {
+  email = 'email',
+}
+
 export type EntityResultList<Entity, ExtensionInterface = {}> = Promise<
   {
     readonly _embedded: { readonly items: ReadonlyArray<Entity> }

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,3 +1,15 @@
+import { EnumCommunicationMethodType } from '../src/rest/types'
+
 export const APP_ID = '575027e58178f56a008b4568'
+export const APP_CHANNEL = 'App-575027e58178f56a008b4568'
 export const APP_PROPERTY_MANAGER_ID = '5a818c07ef5f2f00441146a2'
+export const CATEGORY_ID = '5728504906128762098b456e'
+export const COMMUNICATION_METHOD = {
+  id: '5dd7ca6bfbdbb4af89be9c37',
+  type: EnumCommunicationMethodType.email,
+  value: 'pr-coreyplatt@allthings.me',
+}
+export const CONVERSATION_ID = '5aa7cd7bd4959e004112e136'
+export const SERVICE_PROVIDER_ID = '5a818c07ef5f2f00441146a2'
 export const USER_ID = '50f66beaeabc88ab0e000000'
+export const UTILISATION_PERIOD_ID = '5a9d65cd0ecb330045742be3'


### PR DESCRIPTION
Implement methods to create tickets on users (known tickets) and service providers (anonymous tickets)

BREAKING CHANGE: The `ticketCreate` method has been removed in favour of: `ticketCreateOnUser` (to create a ticket for a user) and `ticketCreateOnServiceProvider` (to create an anonymous ticket on a service provider.
