### PR TITLE
fix: remove read -e -p in preversion command

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prebuild": "npm run clean",
     "build": "tsc -d && cp package.json dist/ && rollup -c && rm dist/package.json",
     "dev": "tsc -w",
-    "preversion": "read -e -p 'This project is setup to automatically publish to NPM. Are you sure you want to manually publish a version? [Yes/n]' YN && [[ $YN == \"yes\" || $YN == \"Yes\" ]] && git pull && yarn check --integrity && yarn security-check && yarn lint && yarn test",
+    "preversion": "git pull && yarn check --integrity && yarn security-check && yarn lint && yarn test",
     "postversion": "git push --tags origin HEAD",
     "prepublishOnly": "npm run build",
     "prettier": "prettier --write",


### PR DESCRIPTION
see: https://allthings-team.slack.com/archives/C0AA1N0CX/p1580371041037100

Somehow it's not possible to use `read -e -p` on the buildkite agents anymore. Question is do we need it anyway?