### PR TITLE
chore: adjust tests relying on siteUrl to pass API validation

### DIFF
--- a/src/rest/index.test.ts
+++ b/src/rest/index.test.ts
@@ -5,6 +5,7 @@ import * as authenticationCodeGrant from '../oauth/authorizationCodeGrant'
 import createTokenStore from '../oauth/createTokenStore'
 import * as makeFetchTokenRequesterModule from '../oauth/makeFetchTokenRequester'
 import * as passwordGrant from '../oauth/passwordGrant'
+import { pseudoRandomString } from '../utils/random'
 
 const redirectUri = 'allthings://redirect'
 
@@ -99,7 +100,10 @@ describe('Rest API Client', () => {
     })
 
     await expect(
-      client.appCreate('foobar', { name: 'foobar', siteUrl: 'foobar.test' }),
+      client.appCreate('foobar', {
+        name: 'foobar',
+        siteUrl: `https://${pseudoRandomString(32)}.info`,
+      }),
     ).rejects.toThrow('Unable to get OAuth2 access token')
   })
 

--- a/src/rest/methods/app.test.ts
+++ b/src/rest/methods/app.test.ts
@@ -1,15 +1,15 @@
 // tslint:disable:no-expression-statement
-import generateId from 'nanoid'
 import restClient from '..'
 import { APP_ID, USER_ID } from '../../../test/constants'
+import { pseudoRandomString } from '../../utils/random'
 
 const client = restClient()
 
 describe('appCreate()', () => {
   it('should create a new App', async () => {
     const result = await client.appCreate(USER_ID, {
-      name: generateId(),
-      siteUrl: generateId(),
+      name: pseudoRandomString(32),
+      siteUrl: `https://${pseudoRandomString(32)}.info`,
     })
 
     expect(result).toBeTruthy()

--- a/src/rest/methods/registrationCode.test.ts
+++ b/src/rest/methods/registrationCode.test.ts
@@ -2,6 +2,7 @@
 import generateId from 'nanoid'
 import restClient from '..'
 import { APP_PROPERTY_MANAGER_ID, USER_ID } from '../../../test/constants'
+import { pseudoRandomString } from '../../utils/random'
 import { EnumTimezone } from '../types'
 import { EnumUnitType } from './unit'
 
@@ -10,8 +11,11 @@ let sharedUtilisationPeriodIds: ReadonlyArray<string> // tslint:disable-line no-
 const client = restClient()
 
 beforeAll(async () => {
-  const name = `Registration Code ${generateId()}`
-  const app = await client.appCreate(USER_ID, { name, siteUrl: generateId() })
+  const name = `Registration Code ${pseudoRandomString()}`
+  const app = await client.appCreate(USER_ID, {
+    name,
+    siteUrl: `https://${pseudoRandomString(32)}.info`,
+  })
 
   const property = await client.propertyCreate(app.id, {
     name,
@@ -44,7 +48,7 @@ beforeAll(async () => {
   ).map(item => item.id)
 })
 
-describe('registrationCodeCreate()', async () => {
+describe('registrationCodeCreate()', () => {
   it('should be able to create a new registration code', async () => {
     const code = generateId()
     const testExternalId = generateId()

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,3 +1,8 @@
+/**
+ * Generates a cryptographically insecure random string
+ * of a given size (16 symbols by default).
+ * Alphabet: 0-9a-z.
+ */
 export function pseudoRandomString(length = 16): string {
   // tslint:disable-next-line no-let
   let token = ''


### PR DESCRIPTION
In some tests we create App specifying `siteUrl` generated by `nanoid`. Apparently some of the strings generated don't pass API validation, causing tests to fail sometimes.
[Example of a failing test](https://buildkite.com/allthings/node-sdk/builds/4656#99a8d574-f0d0-4d55-b0c7-ceafe61a563b/146-244)

Adjusted tests to use our internal `pseudoRandomString` function - that one uses `0-9a-z` as alphabet.
