### PR TITLE
fix: rename and export renamed LookupUserTypes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
 export {
   EnumCountryCode,
   EnumLocale,
+  EnumLookupUserType,
   EnumResource,
   EnumServiceProviderType,
   EnumTimezone,

--- a/src/rest/methods/idLookup.test.ts
+++ b/src/rest/methods/idLookup.test.ts
@@ -4,9 +4,9 @@ import restClient from '..'
 import { APP_ID } from '../../../test/constants'
 import {
   EnumCountryCode,
+  EnumLookupUserType,
   EnumResource,
   EnumServiceProviderType,
-  EnumUserType,
 } from '../types'
 
 const client = restClient()
@@ -73,7 +73,7 @@ describe('lookupIds()', () => {
     expect(await client.lookupIds(APP_ID, {
       externalIds: ['fooAgent'],
       resource: EnumResource.user,
-      userType: EnumUserType.agent
+      userType: EnumLookupUserType.agent
     })).toEqual({
       fooAgent: null,
     })
@@ -81,7 +81,7 @@ describe('lookupIds()', () => {
     expect(await client.lookupIds(APP_ID, {
       externalIds: ['fooTenant'],
       resource: EnumResource.user,
-      userType: EnumUserType.tenant
+      userType: EnumLookupUserType.tenant
     })).toEqual({
       fooTenant: null,
     })

--- a/src/rest/methods/idLookup.ts
+++ b/src/rest/methods/idLookup.ts
@@ -1,4 +1,4 @@
-import { EnumResource, EnumUserType, IAllthingsRestClient } from '../types'
+import { EnumLookupUserType, EnumResource, IAllthingsRestClient } from '../types'
 
 export type LookupIdResult = Promise<{
   readonly [externalId: string]: string | null
@@ -10,7 +10,7 @@ export type MethodLookupIds = (
     readonly resource: EnumResource
     readonly externalIds: string | ReadonlyArray<string>
     readonly parentId?: string
-    readonly userType?: EnumUserType
+    readonly userType?: EnumLookupUserType
   },
 ) => LookupIdResult
 
@@ -22,7 +22,7 @@ export async function lookupIds(
     readonly resource: EnumResource
     readonly externalIds: string | ReadonlyArray<string>
     readonly parentId?: string
-    readonly userType?: EnumUserType
+    readonly userType?: EnumLookupUserType
   },
 ): LookupIdResult {
   return client.post(`/v1/id-lookup/${appId}/${data.resource}`, {

--- a/src/rest/types.ts
+++ b/src/rest/types.ts
@@ -150,7 +150,7 @@ export enum EnumInputChannel {
   WHATS_APP = 'whats_app',
 }
 
-export enum EnumUserType {
+export enum EnumLookupUserType {
   agent = 'agent',
   tenant = 'tenant',
 }


### PR DESCRIPTION
Sorry. I have to PR this again... 🤦🏻‍♂️
There was already an `EnumUserType` 🙄
I renamed the new one to avoid any confusion.