### PR TITLE
feat: get userRelations

### DIFF
--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -93,6 +93,7 @@ import {
   EnumUserRelationType,
   userRelationCreate,
   userRelationDelete,
+  userRelationsGetByUser
 } from './methods/userRelation'
 import {
   EnumUtilisationPeriodType,
@@ -202,6 +203,7 @@ const API_METHODS: ReadonlyArray<any> = [
   // User Relations
   userRelationCreate,
   userRelationDelete,
+  userRelationsGetByUser,
 
   // Utilisation Periods
   utilisationPeriodCreate,

--- a/src/rest/methods/idLookup.test.ts
+++ b/src/rest/methods/idLookup.test.ts
@@ -40,6 +40,7 @@ describe('lookupIds()', () => {
     const serviceProviderParent = await client.serviceProviderCreate({
       externalId: generateId(),
       name: 'Parent',
+      type: EnumServiceProviderType.propertyManager,
     })
 
     const serviceProvider = await client.serviceProviderCreate({

--- a/src/rest/methods/serviceProvider.test.ts
+++ b/src/rest/methods/serviceProvider.test.ts
@@ -17,7 +17,7 @@ const testData = {
   name: 'Foobar Property-manager',
   phoneNumber: '+493434343343',
   readOnly: true,
-  type: EnumServiceProviderType.craftspeople,
+  type: EnumServiceProviderType.propertyManager,
 }
 
 describe('serviceProviderCreate()', () => {
@@ -47,10 +47,12 @@ describe('propertyUpdateById()', () => {
     const serviceProviderParent = await client.serviceProviderCreate({
       externalId: generateId(),
       name: 'Parent',
+      type: EnumServiceProviderType.propertyManager,
     })
     const serviceProvider = await client.serviceProviderCreate({
       ...data,
       parent: serviceProviderParent.id,
+      type: EnumServiceProviderType.craftspeople,
     })
 
     expect(serviceProvider.name).toEqual(data.name)
@@ -59,6 +61,8 @@ describe('propertyUpdateById()', () => {
     const updateData = {
       externalId: generateId(),
       name: 'Bio craftspeople',
+      parent: serviceProviderParent.id,
+      type: EnumServiceProviderType.craftspeople,
     }
     const result = await client.serviceProviderUpdateById(
       serviceProvider.id,

--- a/src/rest/methods/userRelation.test.ts
+++ b/src/rest/methods/userRelation.test.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-expression-statement
 import restClient from '..'
-import { APP_ID } from '../../../test/constants'
+import { APP_ID, APP_PROPERTY_MANAGER_ID } from '../../../test/constants'
 import { createUserAndClient } from '../../../test/helpers'
 import { EnumResource, EnumTimezone } from '../types'
 import { EnumUserRelationType } from './userRelation'
@@ -102,5 +102,53 @@ describe('userRelationCreate()', () => {
     expect(userRelation.responsibilities).toHaveLength(1)
     expect(userRelation.responsibilities[0].properties).toHaveLength(1)
     expect(userRelation.responsibilities[0].properties).toEqual([property2.id])
+  })
+
+  it('should be able to fetch a user`s responsibilities (jobRoles/relations)', async () => {
+    const { user } = await createUserAndClient()
+    const prop1 = 'Foobar Property'
+    const property1 = await apiRestClient.propertyCreate(APP_ID, {
+      name: prop1,
+      timezone: EnumTimezone.EuropeBerlin,
+    })
+    const group1 = await apiRestClient.groupCreate(property1.id, {
+      name: 'Foobar Group1',
+      propertyManagerId: APP_PROPERTY_MANAGER_ID,
+    })
+    await apiRestClient.userRelationCreate(user.id, {
+      ids: [property1.id],
+      level: EnumResource.property,
+      role: testRole1,
+      type: EnumUserRelationType.isResponsible,
+    })
+    const createdUserRelations = await apiRestClient.userRelationCreate(user.id, {
+      ids: [group1.id],
+      level: EnumResource.group,
+      role: testRole2,
+      type: EnumUserRelationType.isResponsible,
+    })
+
+    const userRelations = await apiRestClient.userRelationsGetByUser(user.id)
+
+    expect(userRelations._embedded.items).toHaveLength(1)
+    expect(userRelations._embedded.items[0].id).toEqual(createdUserRelations.id)
+    expect(userRelations._embedded.items[0].user).toEqual(user.id)
+    expect(userRelations._embedded.items[0].responsibilities).toHaveLength(2)
+    expect(userRelations._embedded.items[0].responsibilities[0]).toEqual(
+      expect.objectContaining({
+        groups: [],
+        id: createdUserRelations.responsibilities[0].id,
+        properties: [property1.id],
+        role: testRole1,
+      }),
+    )
+    expect(userRelations._embedded.items[0].responsibilities[1]).toEqual(
+      expect.objectContaining({
+        groups: [group1.id],
+        id: createdUserRelations.responsibilities[1].id,
+        properties: [],
+        role: testRole2,
+      }),
+    )
   })
 })

--- a/src/rest/methods/userRelation.ts
+++ b/src/rest/methods/userRelation.ts
@@ -1,4 +1,4 @@
-import { EnumResource, IAllthingsRestClient } from '../types'
+import { EntityResultList, EnumResource, IAllthingsRestClient } from '../types'
 
 export interface IUserRelation {
   readonly id: string
@@ -14,6 +14,8 @@ export interface IUserRelation {
 }
 
 export type UserRelationResult = Promise<IUserRelation>
+
+export type UserRelationResultList = EntityResultList<IUserRelation>
 
 export enum EnumUserRelationType {
   isResponsible = 'is-responsible',
@@ -39,6 +41,10 @@ export type MethodUserRelationDelete = (
     readonly level: EnumResource
   },
 ) => UserRelationResult
+
+export type MethodUserRelationsGetByUser = (
+  userId: string,
+) => UserRelationResultList
 
 // https://api-doc.allthings.me/#/User/Relations/post_users__userId__user_relations__type_
 export async function userRelationCreate(
@@ -76,4 +82,12 @@ export async function userRelationDelete(
     level: data.level,
     role: data.role,
   })
+}
+
+// https://api-doc.allthings.me/#/User/Relations/get_users__userId__user_relations
+export async function userRelationsGetByUser(
+  client: IAllthingsRestClient,
+  userId: string,
+): UserRelationResultList {
+  return client.get(`/v1/users/${userId}/user-relations`)
 }

--- a/src/rest/types.ts
+++ b/src/rest/types.ts
@@ -80,6 +80,7 @@ import {
 import {
   MethodUserRelationCreate,
   MethodUserRelationDelete,
+  MethodUserRelationsGetByUser
 } from './methods/userRelation'
 import {
   MethodUtilisationPeriodAddRegistrationCode,
@@ -520,6 +521,11 @@ export interface IAllthingsRestClient {
    * Deletes a new user relation
    */
   readonly userRelationDelete: MethodUserRelationDelete
+
+  /**
+   * Get a list of user's current responsibilities - jobRoles
+   */
+  readonly userRelationsGetByUser: MethodUserRelationsGetByUser
 
   // Utilisation Period
 

--- a/src/rest/types.ts
+++ b/src/rest/types.ts
@@ -136,7 +136,7 @@ export enum EnumTimezone {
 }
 
 export enum EnumServiceProviderType {
-  serviceProvider = 'service-provider',
+  propertyManager = 'property-manager',
   craftspeople = 'craftspeople',
 }
 


### PR DESCRIPTION
BREAKING CHANGE:
This PR replaces the ServiceProviderType `service-provider` with `property-manager` which is a breaking change as the api doesn't support `service-provider` anymore. 
It also adds a getter for user's relations or jobRoles or responsibilities (however it is to be named).

See: https://allthings.atlassian.net/browse/APP-5336