### PR TITLE
fix: rollback semantic-release-npm and prevent future failure

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,16 +36,6 @@ steps:
 
   - wait
 
-  - name: release-dry-run
-    <<: *common
-    command: >
-      bin/artifacts-download.sh &&
-      git remote set-url origin https://github.com/allthings/node-sdk.git && 
-      git checkout master &&
-      git pull &&
-      bin/docker-node.sh yarn semantic-release --dry-run
-    branches: !master
-
   - name: release
     <<: *common
     command: >

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,6 +36,16 @@ steps:
 
   - wait
 
+  - name: release-dry-run
+    <<: *common
+    command: >
+      bin/artifacts-download.sh &&
+      git remote set-url origin https://github.com/allthings/node-sdk.git && 
+      git checkout master &&
+      git pull &&
+      bin/docker-node.sh yarn semantic-release --dry-run
+    branches: !master
+
   - name: release
     <<: *common
     command: >

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "https-proxy-agent": ">=3.0.0",
     "serialize-javascript": ">=2.1.1",
     "bin-links": ">=1.1.6",
-    "@semantic-release/npm": "5.3.5",
+    "@semantic-release/npm": "5.0.5",
     "kind-of": ">=6.0.3",
     "acorn": ">=5.7.4 <6.0.0 || >=6.4.1 <7.0.0 || >=7.1.1",
     "minimist": ">=1.2.3"

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "extends": ["@allthings"]
+  "extends": ["@allthings"],
+  "ignoreDeps": ["@semantic-release/npm"]
 }


### PR DESCRIPTION
This PR implements rolling back semantic-release-npm to version 5.0.5