### PR TITLE
fix: make property names in types consistent

### DIFF
--- a/src/rest/delete.ts
+++ b/src/rest/delete.ts
@@ -5,7 +5,7 @@ export type DeleteResult = Promise<any>
 export type MethodHttpDelete = (
   method: string,
   body?: Record<string, any>,
-  detailedResponseFormat?: boolean,
+  returnRawResultObject?: boolean,
 ) => DeleteResult
 
 export default async function del(

--- a/src/rest/get.ts
+++ b/src/rest/get.ts
@@ -5,7 +5,7 @@ export type GetResult = Promise<any>
 export type MethodHttpGet = (
   method: string,
   query?: Record<string, any>,
-  detailedResponseFormat?: boolean,
+  returnRawResultObject?: boolean,
 ) => GetResult
 
 export default async function get(

--- a/src/rest/patch.ts
+++ b/src/rest/patch.ts
@@ -5,7 +5,7 @@ export type PatchResult = Promise<any>
 export type MethodHttpPatch = (
   method: string,
   body?: Record<string, any>,
-  detailedResponseFormat?: boolean,
+  returnRawResultObject?: boolean,
 ) => PatchResult
 
 export default async function patch(

--- a/src/rest/post.ts
+++ b/src/rest/post.ts
@@ -5,7 +5,7 @@ export type PostResult = Promise<any>
 export type MethodHttpPost = (
   method: string,
   body?: Record<string, any>,
-  detailedResponseFormat?: boolean,
+  returnRawResultObject?: boolean,
 ) => PostResult
 
 export default async function post(

--- a/src/rest/put.ts
+++ b/src/rest/put.ts
@@ -5,7 +5,7 @@ export type PutResult = Promise<any>
 export type MethodHttpPut = (
   method: string,
   body?: Record<string, any>,
-  detailedResponseFormat?: boolean,
+  returnRawResultObject?: boolean,
 ) => PutResult
 
 export default async function put(


### PR DESCRIPTION
This PR implements making the property names in the types consistent. Sorry @adieuadieu totally missed these when changing the naming.