### PR TITLE
Feat/6046 tenant account split

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "@semantic-release/npm": "5.0.5",
     "acorn": ">=5.7.4 <6.0.0 || >=6.4.1 <7.0.0 || >=7.1.1",
     "bin-links": ">=1.1.6",
+    "dot-prop": ">=4.2.1 <5.0.0 || >=5.1.1",
     "fstream": ">=1.0.12",
     "handlebars": ">=4.5.3",
     "https-proxy-agent": ">=3.0.0",
@@ -178,7 +179,7 @@
     "mixin-deep": ">=1.3.2",
     "npm-registry-fetch": ">=4.0.5 <5.0.0 || >=8.1.1",
     "npm": ">=6.14.6",
-    "serialize-javascript": ">=2.1.1",
+    "serialize-javascript": ">=3.1.0",
     "set-value": ">=2.0.1",
     "tar": ">=4.4.2",
     "yargs-parser": ">=13.1.2 <14.0.0 || >=15.0.1 <16.0.0 || >=18.1.2"

--- a/src/rest/methods/user.test.ts
+++ b/src/rest/methods/user.test.ts
@@ -118,7 +118,7 @@ describe('getCurrentUser()', () => {
 })
 
 describe('userCreate()', () => {
-  it.only('should be able to create a new user', async () => {
+  it('should be able to create a new user', async () => {
     const data = {
       ...testData,
       code: 'my regcode',

--- a/src/rest/methods/user.test.ts
+++ b/src/rest/methods/user.test.ts
@@ -118,12 +118,14 @@ describe('getCurrentUser()', () => {
 })
 
 describe('userCreate()', () => {
-  it('should be able to create a new user', async () => {
+  it.only('should be able to create a new user', async () => {
     const data = {
       ...testData,
+      code: 'my regcode',
       email: generateId() + '@foobar.test',
       externalId: generateId(),
       plainPassword: generateId(),
+      sendInvitation: false,
     }
     const result = await client.userCreate(APP_ID, generateId(), data)
 

--- a/src/rest/methods/user.ts
+++ b/src/rest/methods/user.ts
@@ -51,6 +51,8 @@ export interface IUser {
   readonly type: EnumUserType | null
   readonly username: string
   readonly readOnly: boolean
+  readonly code: string | null
+  readonly sendInvitation: boolean
 }
 
 export type PartialUser = Partial<IUser>
@@ -292,7 +294,7 @@ export async function userCreatePermissionBatch(
   const { objectId, objectType, roles, startDate, endDate } = permissions
 
   const batch = {
-    batch: roles.map(role => ({
+    batch: roles.map((role) => ({
       endDate: endDate && endDate.toISOString(),
       objectID: objectId,
       objectType,


### PR DESCRIPTION
Adding `code` +  `sendInvitation` to the user creation. This will fail with

`400 Bad Request

    {"errors":{"code":["Unknown field."],"sendInvitation":["Unknown field."]}}`

Until those changes are implemented in the api.